### PR TITLE
Fix uselocale to support non-default locales.

### DIFF
--- a/libc-top-half/musl/src/internal/locale_impl.h
+++ b/libc-top-half/musl/src/internal/locale_impl.h
@@ -42,7 +42,15 @@ hidden char *__gettextdomain(void);
 
 #define CURRENT_UTF8 (!!__pthread_self()->locale->cat[LC_CTYPE])
 #else
-#define CURRENT_LOCALE (*(libc.current_locale = &libc.global_locale, &libc.current_locale))
+// If we haven't set up the current_local field yet, do so. Then return an
+// lvalue for the current_locale field.
+#define CURRENT_LOCALE \
+    (*({ \
+        if (!libc.current_locale) { \
+            libc.current_locale = &libc.global_locale; \
+        } \
+        &libc.current_locale; \
+    }))
 
 #define CURRENT_UTF8 (!!libc.global_locale.cat[LC_CTYPE])
 #endif

--- a/libc-top-half/musl/src/locale/uselocale.c
+++ b/libc-top-half/musl/src/locale/uselocale.c
@@ -10,17 +10,14 @@ locale_t __uselocale(locale_t new)
 	pthread_t self = __pthread_self();
 	locale_t old = self->locale;
 #else
-	locale_t old = &libc.global_locale;
+	locale_t old = libc.current_locale;
 #endif
 	locale_t global = &libc.global_locale;
 
 #if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (new) self->locale = new == LC_GLOBAL_LOCALE ? global : new;
 #else
-        if (new != NULL && new != global && new != LC_GLOBAL_LOCALE) {
-            fputs("non-global locale not supported yet", stderr);
-            __builtin_trap();
-        }
+	if (new) libc.current_locale = new == LC_GLOBAL_LOCALE ? global : new;
 #endif
 
 	return old == global ? LC_GLOBAL_LOCALE : old;


### PR DESCRIPTION
Musl's locales implementation depends on pthreads. Since WASI libc
doesn't yet have pthreads, it currently has alternate code for
supporting locales. Previously, this code just assumed that it only had
to support the default locale, however libc++ uses uselocale with
non-default locals, so add support for that.

With this, the C++ <iostream>-style hello world now works, with
-fno-exceptions.