### PR TITLE
Filter out __FLT16_* macros from predefined-macros.txt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ finish: $(SYSROOT_INC) libc
 	# macros, squash individual compiler names to attempt, toward keeping
 	# these files compiler-independent.
 	# TODO: Undefine __FLOAT128__ for now since it's not in clang 8.0.
+	# TODO: Filter out __FLT16_* for now, as not all versions of clang have these.
 	"$(WASM_CC)" $(WASM_CFLAGS) "$(SYSROOT_SHARE)/include-all.c" \
 	    -E -dM -Wno-\#warnings \
 	    -U__llvm__ \
@@ -443,6 +444,7 @@ finish: $(SYSROOT_INC) libc
 	    -U__VERSION__ \
 	    -U__FLOAT128__ \
 	    | sed -e 's/__[[:upper:][:digit:]]*_ATOMIC_\([[:upper:][:digit:]_]*\)_LOCK_FREE/__compiler_ATOMIC_\1_LOCK_FREE/' \
+	    | grep -v '^#define __FLT16_' \
 	    > "$(SYSROOT_SHARE)/predefined-macros.txt"
 
 	#

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3031,20 +3031,6 @@
 #define __DEFINED_wint_t 
 #define __FINITE_MATH_ONLY__ 0
 #define __FLT(x) (__IS_REAL(x) && sizeof(x) == sizeof(float))
-#define __FLT16_DECIMAL_DIG__ 5
-#define __FLT16_DENORM_MIN__ 5.9604644775390625e-8F16
-#define __FLT16_DIG__ 3
-#define __FLT16_EPSILON__ 9.765625e-4F16
-#define __FLT16_HAS_DENORM__ 1
-#define __FLT16_HAS_INFINITY__ 1
-#define __FLT16_HAS_QUIET_NAN__ 1
-#define __FLT16_MANT_DIG__ 11
-#define __FLT16_MAX_10_EXP__ 4
-#define __FLT16_MAX_EXP__ 15
-#define __FLT16_MAX__ 6.5504e+4F16
-#define __FLT16_MIN_10_EXP__ (-13)
-#define __FLT16_MIN_EXP__ (-14)
-#define __FLT16_MIN__ 6.103515625e-5F16
 #define __FLTCX(x) (__IS_CX(x) && sizeof(x) == sizeof(float complex))
 #define __FLT_DECIMAL_DIG__ 9
 #define __FLT_DENORM_MIN__ 1.40129846e-45F


### PR DESCRIPTION
Whether these are defined or not depends on the version of clang in use,
and they're not that important at this time, so for now just ignore them
for the purposes of this testing output.

This fixes the issue reported in https://github.com/CraneStation/wasi-sdk/issues/6.