### PR TITLE
Add comments explaining changes to upstream source files.

### DIFF
--- a/libc-top-half/musl/include/alltypes.h.in
+++ b/libc-top-half/musl/include/alltypes.h.in
@@ -34,7 +34,7 @@ TYPEDEF unsigned long wctype_t;
 TYPEDEF void * timer_t;
 TYPEDEF int clockid_t;
 TYPEDEF long clock_t;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 STRUCT timeval { time_t tv_sec; suseconds_t tv_usec; };
 STRUCT timespec { time_t tv_sec; long tv_nsec; };
 #else
@@ -70,7 +70,7 @@ TYPEDEF struct __locale_struct * locale_t;
 
 TYPEDEF struct __sigset_t { unsigned long __bits[128/sizeof(long)]; } sigset_t;
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 STRUCT iovec { void *iov_base; size_t iov_len; };
 #else
 #include <__struct_iovec.h>

--- a/libc-top-half/musl/include/arpa/inet.h
+++ b/libc-top-half/musl/include/arpa/inet.h
@@ -13,7 +13,7 @@ uint16_t htons(uint16_t);
 uint32_t ntohl(uint32_t);
 uint16_t ntohs(uint16_t);
 
-#ifdef __wasilibc_unmodified_upstream /* inet_addr */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no inet_addr */
 in_addr_t inet_addr (const char *);
 in_addr_t inet_network (const char *);
 char *inet_ntoa (struct in_addr);
@@ -22,7 +22,7 @@ int inet_pton (int, const char *__restrict, void *__restrict);
 const char *inet_ntop (int, const void *__restrict, char *__restrict, socklen_t);
 
 int inet_aton (const char *, struct in_addr *);
-#ifdef __wasilibc_unmodified_upstream /* inet_makeaddr */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no inet_makeaddr */
 struct in_addr inet_makeaddr(in_addr_t, in_addr_t);
 in_addr_t inet_lnaof(struct in_addr);
 in_addr_t inet_netof(struct in_addr);

--- a/libc-top-half/musl/include/dirent.h
+++ b/libc-top-half/musl/include/dirent.h
@@ -1,7 +1,7 @@
 #ifndef	_DIRENT_H
 #define	_DIRENT_H
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #else
 #include <__header_dirent.h>
 #endif
@@ -19,7 +19,7 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 typedef struct __dirstream DIR;
 #else
 #include <__typedef_DIR.h>
@@ -29,7 +29,7 @@ typedef struct __dirstream DIR;
 #define _DIRENT_HAVE_D_OFF
 #define _DIRENT_HAVE_D_TYPE
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct dirent {
 	ino_t d_ino;
 	off_t d_off;
@@ -62,7 +62,7 @@ long           telldir(DIR *);
 #endif
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define DT_UNKNOWN 0
 #define DT_FIFO 1
 #define DT_CHR 2

--- a/libc-top-half/musl/include/errno.h
+++ b/libc-top-half/musl/include/errno.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #include <bits/errno.h>
 
 #ifdef __GNUC__

--- a/libc-top-half/musl/include/fcntl.h
+++ b/libc-top-half/musl/include/fcntl.h
@@ -1,7 +1,7 @@
 #ifndef	_FCNTL_H
 #define	_FCNTL_H
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #else
 #include <__header_fcntl.h>
 #endif
@@ -40,7 +40,7 @@ int openat(int, const char *, int, ...);
 int posix_fadvise(int, off_t, off_t, int);
 int posix_fallocate(int, off_t, off_t);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define O_SEARCH  O_PATH
 #define O_EXEC    O_PATH
 

--- a/libc-top-half/musl/include/float.h
+++ b/libc-top-half/musl/include/float.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of FLT_ROUNDS */
 int __flt_rounds(void);
 #define FLT_ROUNDS (__flt_rounds())
 #else

--- a/libc-top-half/musl/include/ftw.h
+++ b/libc-top-half/musl/include/ftw.h
@@ -26,13 +26,13 @@ struct FTW {
 	int level;
 };
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
 int ftw(const char *, int (*)(const char *, const struct stat *, int), int);
 #endif
 int nftw(const char *, int (*)(const char *, const struct stat *, int, struct FTW *), int, int);
 
 #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
 #define ftw64 ftw
 #endif
 #define nftw64 nftw

--- a/libc-top-half/musl/include/limits.h
+++ b/libc-top-half/musl/include/limits.h
@@ -61,7 +61,7 @@
 #define SEM_VALUE_MAX 0x7fffffff
 #define SEM_NSEMS_MAX 256
 #define DELAYTIMER_MAX 0x7fffffff
-#ifdef __wasilibc_unmodified_upstream /* mq */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no mq */
 #define MQ_PRIO_MAX 32768
 #endif
 #define LOGIN_NAME_MAX 256
@@ -116,7 +116,7 @@
 #define _POSIX_LOGIN_NAME_MAX   9
 #define _POSIX_MAX_CANON        255
 #define _POSIX_MAX_INPUT        255
-#ifdef __wasilibc_unmodified_upstream /* mq */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no mq */
 #define _POSIX_MQ_OPEN_MAX      8
 #define _POSIX_MQ_PRIO_MAX      32
 #endif

--- a/libc-top-half/musl/include/locale.h
+++ b/libc-top-half/musl/include/locale.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else

--- a/libc-top-half/musl/include/netinet/in.h
+++ b/libc-top-half/musl/include/netinet/in.h
@@ -8,18 +8,18 @@ extern "C" {
 #include <features.h>
 #include <inttypes.h>
 #include <sys/socket.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #else
 #include <__header_netinet_in.h>
 #endif
 
 typedef uint16_t in_port_t;
 typedef uint32_t in_addr_t;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct in_addr { in_addr_t s_addr; };
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct sockaddr_in {
 	sa_family_t sin_family;
 	in_port_t sin_port;
@@ -28,7 +28,7 @@ struct sockaddr_in {
 };
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct in6_addr {
 	union {
 		uint8_t __s6_addr[16];
@@ -41,7 +41,7 @@ struct in6_addr {
 #define s6_addr32 __in6_union.__s6_addr32
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct sockaddr_in6 {
 	sa_family_t     sin6_family;
 	in_port_t       sin6_port;
@@ -83,7 +83,7 @@ uint16_t ntohs(uint16_t);
 
 #define IPPORT_RESERVED 1024
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define IPPROTO_IP       0
 #define IPPROTO_HOPOPTS  0
 #define IPPROTO_ICMP     1

--- a/libc-top-half/musl/include/poll.h
+++ b/libc-top-half/musl/include/poll.h
@@ -9,7 +9,7 @@ extern "C" {
 
 #include <bits/poll.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define POLLIN     0x001
 #define POLLPRI    0x002
 #define POLLOUT    0x004
@@ -30,13 +30,13 @@ extern "C" {
 #include <__header_poll.h>
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 typedef unsigned long nfds_t;
 #else
 #include <__typedef_nfds_t.h>
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct pollfd {
 	int fd;
 	short events;

--- a/libc-top-half/musl/include/pthread.h
+++ b/libc-top-half/musl/include/pthread.h
@@ -55,12 +55,11 @@ extern "C" {
 #define PTHREAD_PROCESS_SHARED 1
 
 
-#ifdef __wasilibc_unmodified_upstream
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 #define PTHREAD_MUTEX_INITIALIZER {{{0}}}
 #define PTHREAD_RWLOCK_INITIALIZER {{{0}}}
 #define PTHREAD_COND_INITIALIZER {{{0}}}
 #else
-/* TODO: Threads support. */
 #define PTHREAD_MUTEX_INITIALIZER 0
 #define PTHREAD_RWLOCK_INITIALIZER 0
 #define PTHREAD_COND_INITIALIZER 0

--- a/libc-top-half/musl/include/setjmp.h
+++ b/libc-top-half/musl/include/setjmp.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream /* setjmp */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no setjmp */
 #include <bits/setjmp.h>
 
 typedef struct __jmp_buf_tag {

--- a/libc-top-half/musl/include/signal.h
+++ b/libc-top-half/musl/include/signal.h
@@ -189,7 +189,7 @@ struct sigevent {
 #define SIGEV_NONE 1
 #define SIGEV_THREAD 2
 
-#ifdef __wasilibc_unmodified_upstream /* realtime signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no realtime signals */
 int __libc_current_sigrtmin(void);
 int __libc_current_sigrtmax(void);
 
@@ -197,7 +197,7 @@ int __libc_current_sigrtmax(void);
 #define SIGRTMAX  (__libc_current_sigrtmax())
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 int kill(pid_t, int);
 
 int sigemptyset(sigset_t *);
@@ -219,14 +219,14 @@ int sigqueue(pid_t, int, union sigval);
 int pthread_sigmask(int, const sigset_t *__restrict, sigset_t *__restrict);
 int pthread_kill(pthread_t, int);
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 void psiginfo(const siginfo_t *, const char *);
 void psignal(int, const char *);
 #endif
 
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 #if defined(_XOPEN_SOURCE) || defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
 int killpg(pid_t, int);
 int sigaltstack(const stack_t *__restrict, stack_t *__restrict);
@@ -254,7 +254,7 @@ void (*sigset(int, void (*)(int)))(int);
 #endif
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 #if defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
 #define NSIG _NSIG
 typedef void (*sig_t)(int);
@@ -278,7 +278,7 @@ int sigandset(sigset_t *, const sigset_t *, const sigset_t *);
 
 typedef int sig_atomic_t;
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 void (*signal(int, void (*)(int)))(int);
 #endif
 int raise(int);

--- a/libc-top-half/musl/include/stdarg.h
+++ b/libc-top-half/musl/include/stdarg.h
@@ -1,7 +1,7 @@
 #ifndef _STDARG_H
 #define _STDARG_H
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's stdarg.h */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libc-top-half/musl/include/stddef.h
+++ b/libc-top-half/musl/include/stddef.h
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's stddef.h */
 #ifndef _STDDEF_H
 #define _STDDEF_H
 

--- a/libc-top-half/musl/include/stdio.h
+++ b/libc-top-half/musl/include/stdio.h
@@ -21,7 +21,7 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else
@@ -35,7 +35,7 @@ extern "C" {
 #undef EOF
 #define EOF (-1)
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #undef SEEK_SET
 #undef SEEK_CUR
 #undef SEEK_END
@@ -53,7 +53,7 @@ extern "C" {
 #define BUFSIZ 1024
 #define FILENAME_MAX 4096
 #define FOPEN_MAX 1000
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no tmpnam */
 #define TMP_MAX 10000
 #define L_tmpnam 20
 #endif
@@ -105,7 +105,7 @@ int putchar(int);
 
 char *fgets(char *__restrict, int, FILE *__restrict);
 #if __STDC_VERSION__ < 201112L
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* gets is obsolete */
 char *gets(char *);
 #else
 char *gets(char *) __attribute__((__deprecated__("gets is not defined on WASI")));
@@ -137,7 +137,7 @@ void perror(const char *);
 int setvbuf(FILE *__restrict, char *__restrict, int, size_t);
 void setbuf(FILE *__restrict, char *__restrict);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no tmpnam or tmpfile */
 char *tmpnam(char *);
 FILE *tmpfile(void);
 #else
@@ -173,7 +173,7 @@ char *ctermid(char *);
 #endif
 
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no tempnam */
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
 #define P_tmpdir "/tmp"

--- a/libc-top-half/musl/include/stdlib.h
+++ b/libc-top-half/musl/include/stdlib.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else

--- a/libc-top-half/musl/include/string.h
+++ b/libc-top-half/musl/include/string.h
@@ -7,14 +7,13 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else
 #define NULL ((void*)0)
 #endif
 #else
-#include <__header_string.h>
 #define __need_NULL
 #include <stddef.h>
 #endif
@@ -99,12 +98,9 @@ char *strcasestr(const char *, const char *);
 void *memmem(const void *, size_t, const void *, size_t);
 void *memrchr(const void *, int, size_t);
 void *mempcpy(void *, const void *, size_t);
+#ifdef __wasilibc_unmodified_upstream /* avoid unprototyped decls; use <libgen.h> */
 #ifndef __cplusplus
-#ifdef __wasilibc_unmodified_upstream
 char *basename();
-#else
-/* Don't use unprototyped functions. */
-char *basename(char *);
 #endif
 #endif
 #endif

--- a/libc-top-half/musl/include/sys/ioctl.h
+++ b/libc-top-half/musl/include/sys/ioctl.h
@@ -1,6 +1,6 @@
 #ifndef	_SYS_IOCTL_H
 #define	_SYS_IOCTL_H
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libc-top-half/musl/include/sys/resource.h
+++ b/libc-top-half/musl/include/sys/resource.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <bits/alltypes.h>
 #include <bits/resource.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no rlimit/rusage */
 typedef unsigned long long rlim_t;
 
 struct rlimit {
@@ -62,7 +62,7 @@ int prlimit(pid_t, int, const struct rlimit *, struct rlimit *);
 #define prlimit64 prlimit
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no rlimit/rusage */
 #define PRIO_MIN (-20)
 #define PRIO_MAX 20
 

--- a/libc-top-half/musl/include/sys/select.h
+++ b/libc-top-half/musl/include/sys/select.h
@@ -17,11 +17,11 @@ extern "C" {
 
 #define FD_SETSIZE 1024
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 typedef unsigned long fd_mask;
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 typedef struct {
 	unsigned long fds_bits[FD_SETSIZE / 8 / sizeof(long)];
 } fd_set;
@@ -37,7 +37,7 @@ typedef struct {
 int select (int, fd_set *__restrict, fd_set *__restrict, fd_set *__restrict, struct timeval *__restrict);
 int pselect (int, fd_set *__restrict, fd_set *__restrict, fd_set *__restrict, const struct timespec *__restrict, const sigset_t *__restrict);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 #define NFDBITS (8*(int)sizeof(long))
 #endif

--- a/libc-top-half/musl/include/sys/socket.h
+++ b/libc-top-half/musl/include/sys/socket.h
@@ -1,6 +1,6 @@
 #ifndef	_SYS_SOCKET_H
 #define	_SYS_SOCKET_H
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #else
 #include <__header_sys_socket.h>
 #endif
@@ -46,7 +46,7 @@ struct linger {
 	int l_linger;
 };
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define SHUT_RD 0
 #define SHUT_WR 1
 #define SHUT_RDWR 2
@@ -316,7 +316,7 @@ struct linger {
 #define SCM_CREDENTIALS 0x02
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct sockaddr {
 	sa_family_t sa_family;
 	char sa_data[14];
@@ -325,7 +325,7 @@ struct sockaddr {
 #include <__struct_sockaddr.h>
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct sockaddr_storage {
 	sa_family_t ss_family;
 	char __ss_padding[128-sizeof(long)-sizeof(sa_family_t)];
@@ -336,42 +336,42 @@ struct sockaddr_storage {
 #endif
 
 int socket (int, int, int);
-#ifdef __wasilibc_unmodified_upstream /* socketpair */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no socketpair */
 int socketpair (int, int, int, int [2]);
 #endif
 
 int shutdown (int, int);
 
 int bind (int, const struct sockaddr *, socklen_t);
-#ifdef __wasilibc_unmodified_upstream /* connect/listen/accept */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no connect/listen/accept */
 int connect (int, const struct sockaddr *, socklen_t);
 int listen (int, int);
 int accept (int, struct sockaddr *__restrict, socklen_t *__restrict);
 int accept4(int, struct sockaddr *__restrict, socklen_t *__restrict, int);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* getsockname/getpeername */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no getsockname/getpeername */
 int getsockname (int, struct sockaddr *__restrict, socklen_t *__restrict);
 int getpeername (int, struct sockaddr *__restrict, socklen_t *__restrict);
 #endif
 
 ssize_t send (int, const void *, size_t, int);
 ssize_t recv (int, void *, size_t, int);
-#ifdef __wasilibc_unmodified_upstream /* sendto/recvfrom */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no sendto/recvfrom */
 ssize_t sendto (int, const void *, size_t, int, const struct sockaddr *, socklen_t);
 ssize_t recvfrom (int, void *__restrict, size_t, int, struct sockaddr *__restrict, socklen_t *__restrict);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* sendmsg/recvmsg */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no sendmsg/recvmsg */
 ssize_t sendmsg (int, const struct msghdr *, int);
 ssize_t recvmsg (int, struct msghdr *, int);
 #endif
 
 int getsockopt (int, int, int, void *__restrict, socklen_t *__restrict);
-#ifdef __wasilibc_unmodified_upstream /* setsockopt */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no setsockopt */
 int setsockopt (int, int, int, const void *, socklen_t);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* sockatmark */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no sockatmark */
 int sockatmark (int);
 #endif
 

--- a/libc-top-half/musl/include/sys/stat.h
+++ b/libc-top-half/musl/include/sys/stat.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #include <bits/stat.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define st_atime st_atim.tv_sec
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
@@ -78,24 +78,24 @@ int stat(const char *__restrict, struct stat *__restrict);
 int fstat(int, struct stat *);
 int lstat(const char *__restrict, struct stat *__restrict);
 int fstatat(int, const char *__restrict, struct stat *__restrict, int);
-#ifdef __wasilibc_unmodified_upstream /* chmod */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no chmod */
 int chmod(const char *, mode_t);
 int fchmod(int, mode_t);
 int fchmodat(int, const char *, mode_t, int);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* umask */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no umask */
 mode_t umask(mode_t);
 #endif
 int mkdir(const char *, mode_t);
-#ifdef __wasilibc_unmodified_upstream /* fifo */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no fifo */
 int mkfifo(const char *, mode_t);
 #endif
 int mkdirat(int, const char *, mode_t);
-#ifdef __wasilibc_unmodified_upstream /* fifo */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no fifo */
 int mkfifoat(int, const char *, mode_t);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* mknod */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no mknod */
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 int mknod(const char *, mode_t, dev_t);
 int mknodat(int, const char *, mode_t, dev_t);
@@ -106,7 +106,7 @@ int futimens(int, const struct timespec [2]);
 int utimensat(int, const char *, const struct timespec [2], int);
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-#ifdef __wasilibc_unmodified_upstream /* chmod */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no chmod */
 int lchmod(const char *, mode_t);
 #endif
 #define S_IREAD S_IRUSR

--- a/libc-top-half/musl/include/sys/syscall.h
+++ b/libc-top-half/musl/include/sys/syscall.h
@@ -1,7 +1,7 @@
 #ifndef _SYS_SYSCALL_H
 #define _SYS_SYSCALL_H
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #include <bits/syscall.h>
 #else
 /* The generic syscall funtion is not yet implemented. */

--- a/libc-top-half/musl/include/sys/times.h
+++ b/libc-top-half/musl/include/sys/times.h
@@ -8,7 +8,7 @@ extern "C" {
 #define __NEED_clock_t
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct tms {
 	clock_t tms_utime;
 	clock_t tms_stime;

--- a/libc-top-half/musl/include/sys/un.h
+++ b/libc-top-half/musl/include/sys/un.h
@@ -14,7 +14,7 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no UNIX-domain sockets */
 struct sockaddr_un {
 	sa_family_t sun_family;
 	char sun_path[108];

--- a/libc-top-half/musl/include/time.h
+++ b/libc-top-half/musl/include/time.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else
@@ -40,7 +40,7 @@ extern "C" {
 #define __tm_zone tm_zone
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct tm {
 	int tm_sec;
 	int tm_min;
@@ -69,7 +69,7 @@ char *asctime (const struct tm *);
 char *ctime (const time_t *);
 int timespec_get(struct timespec *, int);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define CLOCKS_PER_SEC 1000000L
 
 #define TIME_UTC 1
@@ -93,7 +93,7 @@ struct itimerspec {
 	struct timespec it_value;
 };
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define CLOCK_REALTIME           0
 #define CLOCK_MONOTONIC          1
 #define CLOCK_PROCESS_CPUTIME_ID 2
@@ -113,15 +113,15 @@ struct itimerspec {
 int nanosleep (const struct timespec *, struct timespec *);
 int clock_getres (clockid_t, struct timespec *);
 int clock_gettime (clockid_t, struct timespec *);
-#ifdef __wasilibc_unmodified_upstream /* clock_settime */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no clock_settime */
 int clock_settime (clockid_t, const struct timespec *);
 #endif
 int clock_nanosleep (clockid_t, int, const struct timespec *, struct timespec *);
-#ifdef __wasilibc_unmodified_upstream /* clock_getcpuclockid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no clock_getcpuclockid */
 int clock_getcpuclockid (pid_t, clockid_t *);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* timers */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no timers */
 struct sigevent;
 int timer_create (clockid_t, struct sigevent *__restrict, timer_t *__restrict);
 int timer_delete (timer_t);
@@ -145,7 +145,7 @@ struct tm *getdate (const char *);
 
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-#ifdef __wasilibc_unmodified_upstream /* stime */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no stime */
 int stime(const time_t *);
 #endif
 time_t timegm(struct tm *);

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -11,7 +11,7 @@ extern "C" {
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define SEEK_SET 0
 #define SEEK_CUR 1
 #define SEEK_END 2
@@ -19,7 +19,7 @@ extern "C" {
 #include <__header_unistd.h>
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else
@@ -41,13 +41,13 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream /* pipe */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no pipe */
 int pipe(int [2]);
 int pipe2(int [2], int);
 #endif
 int close(int);
 int posix_close(int, int);
-#ifdef __wasilibc_unmodified_upstream /* dup */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no dup */
 int dup(int);
 int dup2(int, int);
 int dup3(int, int, int);
@@ -61,7 +61,7 @@ ssize_t write(int, const void *, size_t);
 ssize_t pread(int, void *, size_t, off_t);
 ssize_t pwrite(int, const void *, size_t, off_t);
 
-#ifdef __wasilibc_unmodified_upstream /* chown */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no chown */
 int chown(const char *, uid_t, gid_t);
 int fchown(int, uid_t, gid_t);
 int lchown(const char *, uid_t, gid_t);
@@ -80,7 +80,7 @@ int rmdir(const char *);
 int truncate(const char *, off_t);
 int ftruncate(int, off_t);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define F_OK 0
 #define R_OK 4
 #define W_OK 2
@@ -90,19 +90,19 @@ int ftruncate(int, off_t);
 int access(const char *, int);
 int faccessat(int, const char *, int, int);
 
-#ifdef __wasilibc_unmodified_upstream /* cwd */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no cwd */
 int chdir(const char *);
 int fchdir(int);
 char *getcwd(char *, size_t);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* signals */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */
 unsigned alarm(unsigned);
 #endif
 unsigned sleep(unsigned);
 int pause(void);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no fork/exec */
 pid_t fork(void);
 int execve(const char *, char *const [], char *const []);
 int execv(const char *, char *const []);
@@ -114,7 +114,7 @@ int fexecve(int, char *const [], char *const []);
 #endif
 _Noreturn void _exit(int);
 
-#ifdef __wasilibc_unmodified_upstream /* getpid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no getpid etc. */
 pid_t getpid(void);
 pid_t getppid(void);
 pid_t getpgrp(void);
@@ -123,17 +123,17 @@ int setpgid(pid_t, pid_t);
 pid_t setsid(void);
 pid_t getsid(pid_t);
 #endif
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no ttyname */
 char *ttyname(int);
 int ttyname_r(int, char *, size_t);
 #endif
 int isatty(int);
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no process groups */
 pid_t tcgetpgrp(int);
 int tcsetpgrp(int, pid_t);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream /* getpid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no getuid etc. */
 uid_t getuid(void);
 uid_t geteuid(void);
 gid_t getgid(void);
@@ -164,15 +164,15 @@ size_t confstr(int, char *, size_t);
 #define F_LOCK  1
 #define F_TLOCK 2
 #define F_TEST  3
-#ifdef __wasilibc_unmodified_upstream /* getpid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no setreuid */
 int setreuid(uid_t, uid_t);
 int setregid(gid_t, gid_t);
 #endif
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no POSIX file locking */
 int lockf(int, int, off_t);
 #endif
 long gethostid(void);
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no nice, sync, or setpgrp */
 int nice(int);
 void sync(void);
 pid_t setpgrp(void);
@@ -192,11 +192,11 @@ unsigned ualarm(unsigned, unsigned);
 #define L_SET 0
 #define L_INCR 1
 #define L_XTND 2
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no brk */
 int brk(void *);
 #endif
 void *sbrk(intptr_t);
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no processes */
 pid_t vfork(void);
 int vhangup(void);
 int chroot(const char *);
@@ -221,19 +221,19 @@ int getentropy(void *, size_t);
 
 #ifdef _GNU_SOURCE
 extern char **environ;
-#ifdef __wasilibc_unmodified_upstream /* getpid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no get/setresuid */
 int setresuid(uid_t, uid_t, uid_t);
 int setresgid(gid_t, gid_t, gid_t);
 int getresuid(uid_t *, uid_t *, uid_t *);
 int getresgid(gid_t *, gid_t *, gid_t *);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* cwd */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no cwd */
 char *get_current_dir_name(void);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* syncfs */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no syncfs */
 int syncfs(int);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* getpid */
+#ifdef __wasilibc_unmodified_upstream /* WASI has no eaccess */
 int euidaccess(const char *, int);
 int eaccess(const char *, int);
 #endif
@@ -261,7 +261,7 @@ int eaccess(const char *, int);
 #define _POSIX_ADVISORY_INFO    _POSIX_VERSION
 #define _POSIX_CHOWN_RESTRICTED 1
 #define _POSIX_IPV6             _POSIX_VERSION
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no processes, mmap, or mq */
 #define _POSIX_JOB_CONTROL      1
 #define _POSIX_MAPPED_FILES     _POSIX_VERSION
 #define _POSIX_MEMLOCK          _POSIX_VERSION
@@ -271,12 +271,12 @@ int eaccess(const char *, int);
 #endif
 #define _POSIX_FSYNC            _POSIX_VERSION
 #define _POSIX_NO_TRUNC         1
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no raw sockets */
 #define _POSIX_RAW_SOCKETS      _POSIX_VERSION
 #endif
 #define _POSIX_REALTIME_SIGNALS _POSIX_VERSION
 #define _POSIX_REGEXP           1
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no processes */
 #define _POSIX_SAVED_IDS        1
 #define _POSIX_SHELL            1
 #define _POSIX_SPAWN            _POSIX_VERSION
@@ -298,7 +298,7 @@ int eaccess(const char *, int);
 #define _POSIX_BARRIERS         _POSIX_VERSION
 #define _POSIX_SPIN_LOCKS       _POSIX_VERSION
 #define _POSIX_READER_WRITER_LOCKS _POSIX_VERSION
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* WASI has no POSIX async I/O, semaphores, or shared memory */
 #define _POSIX_ASYNCHRONOUS_IO  _POSIX_VERSION
 #define _POSIX_SEMAPHORES       _POSIX_VERSION
 #define _POSIX_SHARED_MEMORY_OBJECTS _POSIX_VERSION

--- a/libc-top-half/musl/include/wchar.h
+++ b/libc-top-half/musl/include/wchar.h
@@ -34,7 +34,7 @@ extern "C" {
 #define WCHAR_MIN (-1-0x7fffffff+L'\0')
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
 #ifdef __cplusplus
 #define NULL 0L
 #else

--- a/libc-top-half/musl/src/conf/sysconf.c
+++ b/libc-top-half/musl/src/conf/sysconf.c
@@ -10,7 +10,7 @@
 #define JT(x) (-256|(x))
 #define VER JT(1)
 #define JT_ARG_MAX JT(2)
-#ifdef __wasilibc_unmodified_upstream // mq
+#ifdef __wasilibc_unmodified_upstream // WASI has no mq
 #define JT_MQ_PRIO_MAX JT(3)
 #endif
 #define JT_PAGE_SIZE JT(4)
@@ -28,7 +28,7 @@ long sysconf(int name)
 {
 	static const short values[] = {
 		[_SC_ARG_MAX] = JT_ARG_MAX,
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no processes
 		[_SC_CHILD_MAX] = RLIM(NPROC),
 #else
                 // Not supported on wasi.
@@ -36,12 +36,13 @@ long sysconf(int name)
 #endif
 		[_SC_CLK_TCK] = 100,
 		[_SC_NGROUPS_MAX] = 32,
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no rlimit
 		[_SC_OPEN_MAX] = RLIM(NOFILE),
 #else
-                // Not supported on wasi.
+		// Rlimit is not supported on wasi.
 		[_SC_OPEN_MAX] = -1,
 #endif
+
 		[_SC_STREAM_MAX] = -1,
 		[_SC_TZNAME_MAX] = TZNAME_MAX,
 		[_SC_JOB_CONTROL] = 1,
@@ -64,13 +65,13 @@ long sysconf(int name)
 		[_SC_AIO_MAX] = -1,
 		[_SC_AIO_PRIO_DELTA_MAX] = JT_ZERO, /* ?? */
 		[_SC_DELAYTIMER_MAX] = JT_DELAYTIMER_MAX,
-#ifdef __wasilibc_unmodified_upstream // mq
+#ifdef __wasilibc_unmodified_upstream // WASI has no mq
 		[_SC_MQ_OPEN_MAX] = -1,
 		[_SC_MQ_PRIO_MAX] = JT_MQ_PRIO_MAX,
 #endif
 		[_SC_VERSION] = VER,
 		[_SC_PAGE_SIZE] = JT_PAGE_SIZE,
-#ifdef __wasilibc_unmodified_upstream // realtime signals
+#ifdef __wasilibc_unmodified_upstream // WASI has no realtime signals
 		[_SC_RTSIG_MAX] = _NSIG - 1 - 31 - 3,
 #else
                 // Not supported on wasi.
@@ -192,7 +193,7 @@ long sysconf(int name)
 	} else if (values[name] >= -1) {
 		return values[name];
 	} else if (values[name] < -256) {
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no getrlimit
 		struct rlimit lim;
 		getrlimit(values[name]&16383, &lim);
 		if (lim.rlim_cur == RLIM_INFINITY)
@@ -210,7 +211,7 @@ long sysconf(int name)
 		return _POSIX_VERSION;
 	case JT_ARG_MAX & 255:
 		return ARG_MAX;
-#ifdef __wasilibc_unmodified_upstream // mq
+#ifdef __wasilibc_unmodified_upstream // WASI has no mq
 	case JT_MQ_PRIO_MAX & 255:
 		return MQ_PRIO_MAX;
 #endif
@@ -233,7 +234,7 @@ long sysconf(int name)
                 // With no thread support, just say there's 1 processor.
 		return 1;
 #endif
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no sysinfo
 	case JT_PHYS_PAGES & 255:
 	case JT_AVPHYS_PAGES & 255: ;
 		unsigned long long mem;

--- a/libc-top-half/musl/src/exit/exit.c
+++ b/libc-top-half/musl/src/exit/exit.c
@@ -26,7 +26,7 @@ static void libc_exit_fini(void)
 weak_alias(libc_exit_fini, __libc_exit_fini);
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI libc uses a custom exit
 _Noreturn void exit(int code)
 {
 	__funcs_on_exit();

--- a/libc-top-half/musl/src/include/errno.h
+++ b/libc-top-half/musl/src/include/errno.h
@@ -3,7 +3,7 @@
 
 #include "../../include/errno.h"
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Use alternate WASI libc headers
 hidden int *___errno_location(void);
 
 #undef errno

--- a/libc-top-half/musl/src/internal/floatscan.c
+++ b/libc-top-half/musl/src/internal/floatscan.c
@@ -5,7 +5,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <ctype.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #endif

--- a/libc-top-half/musl/src/internal/libm.h
+++ b/libc-top-half/musl/src/internal/libm.h
@@ -71,7 +71,7 @@ union ldshape {
 #error Unsupported long double representation
 #endif
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no floating-point status flags
 #define FORCE_EVAL(x) do {                        \
 	if (sizeof(x) == sizeof(float)) {         \
 		volatile float __x;               \

--- a/libc-top-half/musl/src/locale/locale_map.c
+++ b/libc-top-half/musl/src/locale/locale_map.c
@@ -1,6 +1,6 @@
 #include <locale.h>
 #include <string.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no mmap
 #include <sys/mman.h>
 #endif
 #include "locale_impl.h"
@@ -34,11 +34,9 @@ const struct __locale_map *__get_locale(int cat, const char *val)
 	size_t l, n;
 
 	if (!*val) {
-#ifdef __wasilibc_unmodified_upstream // getenv
 		(val = getenv("LC_ALL")) && *val ||
 		(val = getenv(envvars[cat])) && *val ||
 		(val = getenv("LANG")) && *val ||
-#endif
 		(val = "C.UTF-8");
 	}
 
@@ -66,7 +64,7 @@ const struct __locale_map *__get_locale(int cat, const char *val)
 			return p;
 		}
 
-#ifdef __wasilibc_unmodified_upstream // locales
+#ifdef __wasilibc_unmodified_upstream // WASI has no mmap, though this code could be made to use something else
 	if (!libc.secure) path = getenv("MUSL_LOCPATH");
 	/* FIXME: add a default path? */
 

--- a/libc-top-half/musl/src/math/fmaf.c
+++ b/libc-top-half/musl/src/math/fmaf.c
@@ -80,7 +80,7 @@ float fmaf(float x, float y, float z)
 #ifdef FE_TOWARDZERO
 	fesetround(FE_TOWARDZERO);
 #endif
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't need old GCC workarounds
 	volatile double vxy = xy;  /* XXX work around gcc CSE bug */
 #else
 	double vxy = xy;

--- a/libc-top-half/musl/src/math/fmal.c
+++ b/libc-top-half/musl/src/math/fmal.c
@@ -256,7 +256,7 @@ long double fmal(long double x, long double y, long double z)
 		 * the correct sign.
 		 */
 		fesetround(oround);
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't need old GCC workarounds
 		volatile long double vzs = zs; /* XXX gcc CSE bug workaround */
 #else
 		long double vzs = zs;

--- a/libc-top-half/musl/src/math/powl.c
+++ b/libc-top-half/musl/src/math/powl.c
@@ -186,7 +186,7 @@ static const long double MINLOGL = -1.13994985314888605586758E4L;
 static const long double LOGE2L = 6.9314718055994530941723E-1L;
 static const long double huge = 0x1p10000L;
 /* XXX Prevent gcc from erroneously constant folding this. */
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't need old GCC workarounds
 static const volatile long double twom10000 = 0x1p-10000L;
 #else
 static const long double twom10000 = 0x1p-10000L;

--- a/libc-top-half/musl/src/misc/fmtmsg.c
+++ b/libc-top-half/musl/src/misc/fmtmsg.c
@@ -27,11 +27,7 @@ int fmtmsg(long classification, const char *label, int severity,
            const char *text, const char *action, const char *tag)
 {
 	int ret = 0, i, consolefd, verb = 0;
-#ifdef __wasilibc_unmodified_upstream // getenv
 	char *errstring = MM_NULLSEV, *cmsg = getenv("MSGVERB");
-#else
-	char *errstring = MM_NULLSEV, *cmsg = NULL;
-#endif
 	char *const msgs[] = {
 		"label", "severity", "text", "action", "tag", NULL
 	};

--- a/libc-top-half/musl/src/misc/uname.c
+++ b/libc-top-half/musl/src/misc/uname.c
@@ -1,13 +1,13 @@
 #include <sys/utsname.h>
 #include "syscall.h"
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Implement uname with placeholders
 #else
 #include <string.h>
 #endif
 
 int uname(struct utsname *uts)
 {
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Implement uname with placeholders
 	return syscall(SYS_uname, uts);
 #else
         // Just fill in the fields with placeholder values.

--- a/libc-top-half/musl/src/stdio/__fdopen.c
+++ b/libc-top-half/musl/src/stdio/__fdopen.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <string.h>
 #include "libc.h"
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #else
 #include <__function___isatty.h>
 #endif
@@ -13,7 +13,7 @@
 FILE *__fdopen(int fd, const char *mode)
 {
 	FILE *f;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	struct winsize wsz;
 #endif
 
@@ -33,7 +33,7 @@ FILE *__fdopen(int fd, const char *mode)
 	if (!strchr(mode, '+')) f->flags = (*mode == 'r') ? F_NOWR : F_NORD;
 
 	/* Apply close-on-exec flag */
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	if (strchr(mode, 'e')) __syscall(SYS_fcntl, fd, F_SETFD, FD_CLOEXEC);
 #else
 	if (strchr(mode, 'e')) fcntl(fd, F_SETFD, FD_CLOEXEC);
@@ -41,13 +41,13 @@ FILE *__fdopen(int fd, const char *mode)
 
 	/* Set append mode on fd if opened for append */
 	if (*mode == 'a') {
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 		int flags = __syscall(SYS_fcntl, fd, F_GETFL);
 #else
 		int flags = fcntl(fd, F_GETFL);
 #endif
 		if (!(flags & O_APPEND))
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 			__syscall(SYS_fcntl, fd, F_SETFL, flags | O_APPEND);
 #else
 			fcntl(fd, F_SETFL, flags | O_APPEND);
@@ -61,7 +61,7 @@ FILE *__fdopen(int fd, const char *mode)
 
 	/* Activate line buffered mode for terminals */
 	f->lbf = EOF;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	if (!(f->flags & F_NOWR) && !__syscall(SYS_ioctl, fd, TIOCGWINSZ, &wsz))
 #else
 	if (!(f->flags & F_NOWR) && __isatty(fd))

--- a/libc-top-half/musl/src/stdio/__fopen_rb_ca.c
+++ b/libc-top-half/musl/src/stdio/__fopen_rb_ca.c
@@ -6,13 +6,13 @@ FILE *__fopen_rb_ca(const char *filename, FILE *f, unsigned char *buf, size_t le
 {
 	memset(f, 0, sizeof *f);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no sys_open
 	f->fd = sys_open(filename, O_RDONLY|O_CLOEXEC);
 #else
 	f->fd = open(filename, O_RDONLY|O_CLOEXEC);
 #endif
 	if (f->fd < 0) return 0;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	__syscall(SYS_fcntl, f->fd, F_SETFD, FD_CLOEXEC);
 #else
 	fcntl(f->fd, F_SETFD, FD_CLOEXEC);

--- a/libc-top-half/musl/src/stdio/__stdio_close.c
+++ b/libc-top-half/musl/src/stdio/__stdio_close.c
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #else
 #include <unistd.h>
 #endif
@@ -13,7 +13,7 @@ weak_alias(dummy, __aio_close);
 
 int __stdio_close(FILE *f)
 {
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	return syscall(SYS_close, __aio_close(f->fd));
 #else
 	return close(__aio_close(f->fd));

--- a/libc-top-half/musl/src/stdio/__stdio_read.c
+++ b/libc-top-half/musl/src/stdio/__stdio_read.c
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #else
 #include <unistd.h>
 #endif
@@ -13,7 +13,7 @@ size_t __stdio_read(FILE *f, unsigned char *buf, size_t len)
 	};
 	ssize_t cnt;
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	cnt = iov[0].iov_len ? syscall(SYS_readv, f->fd, iov, 2)
 		: syscall(SYS_read, f->fd, iov[1].iov_base, iov[1].iov_len);
 #else

--- a/libc-top-half/musl/src/stdio/__stdio_seek.c
+++ b/libc-top-half/musl/src/stdio/__stdio_seek.c
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #else
 #include <unistd.h>
 #endif
@@ -9,14 +9,14 @@ off_t __stdio_seek(FILE *f, off_t off, int whence)
 {
 	off_t ret;
 #ifdef SYS__llseek
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	if (syscall(SYS__llseek, f->fd, off>>32, off, &ret, whence)<0)
 #else
 	if (llseek(f->fd, off>>32, off, &ret, whence)<0)
 #endif
 		ret = -1;
 #else
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	ret = syscall(SYS_lseek, f->fd, off, whence);
 #else
 	ret = lseek(f->fd, off, whence);

--- a/libc-top-half/musl/src/stdio/__stdio_write.c
+++ b/libc-top-half/musl/src/stdio/__stdio_write.c
@@ -12,7 +12,7 @@ size_t __stdio_write(FILE *f, const unsigned char *buf, size_t len)
 	int iovcnt = 2;
 	ssize_t cnt;
 	for (;;) {
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 		cnt = syscall(SYS_writev, f->fd, iov, iovcnt);
 #else
 		cnt = writev(f->fd, iov, iovcnt);

--- a/libc-top-half/musl/src/stdio/__stdout_write.c
+++ b/libc-top-half/musl/src/stdio/__stdout_write.c
@@ -1,17 +1,17 @@
 #include "stdio_impl.h"
 #include <sys/ioctl.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // use isatty rather than manual ioctl
 #else
 #include <__function___isatty.h>
 #endif
 
 size_t __stdout_write(FILE *f, const unsigned char *buf, size_t len)
 {
-#ifdef __wasilibc_unmodified_upstream // isatty
+#ifdef __wasilibc_unmodified_upstream // use isatty rather than manual ioctl
 	struct winsize wsz;
 #endif
 	f->write = __stdio_write;
-#ifdef __wasilibc_unmodified_upstream // isatty
+#ifdef __wasilibc_unmodified_upstream // use isatty rather than manual ioctl
 	if (!(f->flags & F_SVB) && __syscall(SYS_ioctl, f->fd, TIOCGWINSZ, &wsz))
 #else
 	if (!(f->flags & F_SVB) && !__isatty(f->fd))

--- a/libc-top-half/musl/src/stdio/fopen.c
+++ b/libc-top-half/musl/src/stdio/fopen.c
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #else
 #include <unistd.h>
 #endif
@@ -22,13 +22,13 @@ FILE *fopen(const char *restrict filename, const char *restrict mode)
 	/* Compute the flags to pass to open() */
 	flags = __fmodeflags(mode);
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no sys_open
 	fd = sys_open(filename, flags, 0666);
 #else
 	fd = open(filename, flags, 0666);
 #endif
 	if (fd < 0) return 0;
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	if (flags & O_CLOEXEC)
 		__syscall(SYS_fcntl, fd, F_SETFD, FD_CLOEXEC);
 #else
@@ -38,7 +38,7 @@ FILE *fopen(const char *restrict filename, const char *restrict mode)
 	f = __fdopen(fd, mode);
 	if (f) return f;
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 	__syscall(SYS_close, fd);
 #else
         close(fd);

--- a/libc-top-half/musl/src/stdio/freopen.c
+++ b/libc-top-half/musl/src/stdio/freopen.c
@@ -1,11 +1,11 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall, dup
 #include "stdio_impl.h"
 #else
 #include <wasi/libc.h>
 #endif
 #include <fcntl.h>
 #include <unistd.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall, dup
 #else
 // Move this below fcntl.h and unistd.h so that the __syscall macro doesn't
 // cause trouble.
@@ -31,13 +31,13 @@ FILE *freopen(const char *restrict filename, const char *restrict mode, FILE *re
 
 	if (!filename) {
 		if (fl&O_CLOEXEC)
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 			__syscall(SYS_fcntl, f->fd, F_SETFD, FD_CLOEXEC);
 #else
 			fcntl(f->fd, F_SETFD, FD_CLOEXEC);
 #endif
 		fl &= ~(O_CREAT|O_EXCL|O_CLOEXEC);
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 		if (syscall(SYS_fcntl, f->fd, F_SETFL, fl) < 0)
 #else
 		if (fcntl(f->fd, F_SETFL, fl) < 0)
@@ -47,7 +47,7 @@ FILE *freopen(const char *restrict filename, const char *restrict mode, FILE *re
 		f2 = fopen(filename, mode);
 		if (!f2) goto fail;
 		if (f2->fd == f->fd) f2->fd = -1; /* avoid closing in fclose */
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI has no dup
 		else if (__dup3(f2->fd, f->fd, fl&O_CLOEXEC)<0) goto fail2;
 #else
                 // WASI doesn't have dup3, but does have a way to renumber

--- a/libc-top-half/musl/src/stdio/printf.c
+++ b/libc-top-half/musl/src/stdio/printf.c
@@ -10,7 +10,7 @@ int printf(const char *restrict fmt, ...)
 	va_end(ap);
 	return ret;
 }
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 weak_alias(printf, iprintf);
 weak_alias(printf, printf_no_Lf);

--- a/libc-top-half/musl/src/stdio/vfprintf.c
+++ b/libc-top-half/musl/src/stdio/vfprintf.c
@@ -10,7 +10,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include <float.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #endif

--- a/libc-top-half/musl/src/stdio/vfscanf.c
+++ b/libc-top-half/musl/src/stdio/vfscanf.c
@@ -6,7 +6,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdint.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #endif

--- a/libc-top-half/musl/src/stdio/vfwprintf.c
+++ b/libc-top-half/musl/src/stdio/vfwprintf.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <wchar.h>
 #include <inttypes.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #endif

--- a/libc-top-half/musl/src/stdlib/strtod.c
+++ b/libc-top-half/musl/src/stdlib/strtod.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #define __NEED_locale_t
@@ -47,7 +47,7 @@ long double strtold(const char *restrict s, char **restrict p)
 #endif
 }
 
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't support signature-changing aliases
 weak_alias(strtof, strtof_l);
 weak_alias(strtod, strtod_l);
 weak_alias(strtold, strtold_l);

--- a/libc-top-half/musl/src/stdlib/wcstod.c
+++ b/libc-top-half/musl/src/stdlib/wcstod.c
@@ -1,4 +1,4 @@
-#ifdef __wasilibc_unmodified_upstream
+#ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 #include "printscan.h"
 #endif

--- a/libc-top-half/musl/src/time/getdate.c
+++ b/libc-top-half/musl/src/time/getdate.c
@@ -10,11 +10,7 @@ struct tm *getdate(const char *s)
 {
 	static struct tm tmbuf;
 	struct tm *ret = 0;
-#ifdef __wasilibc_unmodified_upstream // getenv
 	char *datemsk = getenv("DATEMSK");
-#else
-	char *datemsk = NULL;
-#endif
 	FILE *f = 0;
 	char fmt[100], *p;
 	int cs;


### PR DESCRIPTION
Add at least a one-line comment on every
`#ifdef __wasilibc_unmodified_upstream` briefly indicating what its
purpose is.

While here, reenable some of the code that was previously disabled when
getenv wasn't supported, as getenv is now supported.