### PR TITLE
Don't install <ucontext.h> or <sys/ucontext.h> for WASI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,9 @@ $(SYSROOT_INC):
 	      "$(SYSROOT_INC)/ulimit.h" \
 	      "$(SYSROOT_INC)/xattr.h" \
 	      "$(SYSROOT_INC)/wordexp.h" \
-	      "$(SYSROOT_INC)/spawn.h"
+	      "$(SYSROOT_INC)/spawn.h" \
+	      "$(SYSROOT_INC)/ucontext.h" \
+	      "$(SYSROOT_INC)/sys/ucontext.h"
 
 ifeq ($(BUILD_LIBC_BOTTOM_HALF),no)
 override CRT_SOURCES = $(BASICS_CRT_SOURCES)

--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -165,7 +165,6 @@
 #include <sys/timex.h>
 #include <sys/ttydefaults.h>
 #include <sys/types.h>
-#include <sys/ucontext.h>
 #include <sys/uio.h>
 #include <sys/un.h>
 #include <sys/utsname.h>
@@ -178,7 +177,6 @@
 #include <threads.h>
 #include <time.h>
 #include <uchar.h>
-#include <ucontext.h>
 #include <unistd.h>
 #include <utime.h>
 #include <values.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -1499,7 +1499,6 @@
 #define ND_ROUTER_SOLICIT 133
 #define NEW_ENV_VALUE 1
 #define NEW_ENV_VAR 0
-#define NGREG (sizeof(gregset_t)/sizeof(greg_t))
 #define NGROUPS 32
 #define NGROUPS_MAX 32
 #define NL0 0000000
@@ -2903,7 +2902,6 @@
 #define _THREADS_H 
 #define _TIME_H 
 #define _UCHAR_H 
-#define _UCONTEXT_H 
 #define _UNISTD_H 
 #define _UTIME_H 
 #define _VALUES_H 

--- a/libc-top-half/musl/include/signal.h
+++ b/libc-top-half/musl/include/signal.h
@@ -11,8 +11,10 @@ extern "C" {
  || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
 
+#ifdef __wasilibc_unmodified_upstream /* WASI has no ucontext support */
 #ifdef _GNU_SOURCE
 #define __ucontext ucontext
+#endif
 #endif
 
 #define __NEED_size_t


### PR DESCRIPTION
WASI doesn't support `getcontext`, `setcontext`, or related functions.