### PR TITLE
Add a basics implementation of <inttypes.h>.

### DIFF
--- a/basics/include/__header_inttypes.h
+++ b/basics/include/__header_inttypes.h
@@ -1,0 +1,182 @@
+#ifndef __wasm_basics___include_inttypes_h
+#define __wasm_basics___include_inttypes_h
+
+#include <stdint.h>
+
+#define __need_wchar_t
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct { intmax_t quot, rem; } imaxdiv_t;
+
+intmax_t  imaxabs(intmax_t);
+imaxdiv_t imaxdiv(intmax_t, intmax_t);
+intmax_t  strtoimax(const char *__restrict, char **__restrict, int);
+uintmax_t strtoumax(const char *__restrict, char **__restrict, int);
+intmax_t  wcstoimax(const wchar_t *__restrict, wchar_t **__restrict, int);
+uintmax_t wcstoumax(const wchar_t *__restrict, wchar_t **__restrict, int);
+
+#define PRId16 __INT16_FMTd__
+#define PRIi16 __INT16_FMTi__
+#define PRId32 __INT32_FMTd__
+#define PRIi32 __INT32_FMTi__
+#define PRId64 __INT64_FMTd__
+#define PRIi64 __INT64_FMTi__
+#define PRId8 __INT8_FMTd__
+#define PRIi8 __INT8_FMTi__
+#define PRIdMAX __INTMAX_FMTd__
+#define PRIiMAX __INTMAX_FMTi__
+#define PRIdPTR __INTPTR_FMTd__
+#define PRIiPTR __INTPTR_FMTi__
+#define PRIdFAST16 __INT_FAST16_FMTd__
+#define PRIiFAST16 __INT_FAST16_FMTi__
+#define PRIdFAST32 __INT_FAST32_FMTd__
+#define PRIiFAST32 __INT_FAST32_FMTi__
+#define PRIdFAST64 __INT_FAST64_FMTd__
+#define PRIiFAST64 __INT_FAST64_FMTi__
+#define PRIdFAST8 __INT_FAST8_FMTd__
+#define PRIiFAST8 __INT_FAST8_FMTi__
+#define PRIdLEAST16 __INT_LEAST16_FMTd__
+#define PRIiLEAST16 __INT_LEAST16_FMTi__
+#define PRIdLEAST32 __INT_LEAST32_FMTd__
+#define PRIiLEAST32 __INT_LEAST32_FMTi__
+#define PRIdLEAST64 __INT_LEAST64_FMTd__
+#define PRIiLEAST64 __INT_LEAST64_FMTi__
+#define PRIdLEAST8 __INT_LEAST8_FMTd__
+#define PRIiLEAST8 __INT_LEAST8_FMTi__
+#define PRIX16 __UINT16_FMTX__
+#define PRIo16 __UINT16_FMTo__
+#define PRIu16 __UINT16_FMTu__
+#define PRIx16 __UINT16_FMTx__
+#define PRIX32 __UINT32_FMTX__
+#define PRIo32 __UINT32_FMTo__
+#define PRIu32 __UINT32_FMTu__
+#define PRIx32 __UINT32_FMTx__
+#define PRIX64 __UINT64_FMTX__
+#define PRIo64 __UINT64_FMTo__
+#define PRIu64 __UINT64_FMTu__
+#define PRIx64 __UINT64_FMTx__
+#define PRIX8 __UINT8_FMTX__
+#define PRIo8 __UINT8_FMTo__
+#define PRIu8 __UINT8_FMTu__
+#define PRIx8 __UINT8_FMTx__
+#define PRIXMAX __UINTMAX_FMTX__
+#define PRIoMAX __UINTMAX_FMTo__
+#define PRIuMAX __UINTMAX_FMTu__
+#define PRIxMAX __UINTMAX_FMTx__
+#define PRIXPTR __UINTPTR_FMTX__
+#define PRIoPTR __UINTPTR_FMTo__
+#define PRIuPTR __UINTPTR_FMTu__
+#define PRIxPTR __UINTPTR_FMTx__
+#define PRIXFAST16 __UINT_FAST16_FMTX__
+#define PRIoFAST16 __UINT_FAST16_FMTo__
+#define PRIuFAST16 __UINT_FAST16_FMTu__
+#define PRIxFAST16 __UINT_FAST16_FMTx__
+#define PRIXFAST32 __UINT_FAST32_FMTX__
+#define PRIoFAST32 __UINT_FAST32_FMTo__
+#define PRIuFAST32 __UINT_FAST32_FMTu__
+#define PRIxFAST32 __UINT_FAST32_FMTx__
+#define PRIXFAST64 __UINT_FAST64_FMTX__
+#define PRIoFAST64 __UINT_FAST64_FMTo__
+#define PRIuFAST64 __UINT_FAST64_FMTu__
+#define PRIxFAST64 __UINT_FAST64_FMTx__
+#define PRIXFAST8 __UINT_FAST8_FMTX__
+#define PRIoFAST8 __UINT_FAST8_FMTo__
+#define PRIuFAST8 __UINT_FAST8_FMTu__
+#define PRIxFAST8 __UINT_FAST8_FMTx__
+#define PRIXLEAST16 __UINT_LEAST16_FMTX__
+#define PRIoLEAST16 __UINT_LEAST16_FMTo__
+#define PRIuLEAST16 __UINT_LEAST16_FMTu__
+#define PRIxLEAST16 __UINT_LEAST16_FMTx__
+#define PRIXLEAST32 __UINT_LEAST32_FMTX__
+#define PRIoLEAST32 __UINT_LEAST32_FMTo__
+#define PRIuLEAST32 __UINT_LEAST32_FMTu__
+#define PRIxLEAST32 __UINT_LEAST32_FMTx__
+#define PRIXLEAST64 __UINT_LEAST64_FMTX__
+#define PRIoLEAST64 __UINT_LEAST64_FMTo__
+#define PRIuLEAST64 __UINT_LEAST64_FMTu__
+#define PRIxLEAST64 __UINT_LEAST64_FMTx__
+#define PRIXLEAST8 __UINT_LEAST8_FMTX__
+#define PRIoLEAST8 __UINT_LEAST8_FMTo__
+#define PRIuLEAST8 __UINT_LEAST8_FMTu__
+#define PRIxLEAST8 __UINT_LEAST8_FMTx__
+
+#define SCNd16 __INT16_FMTd__
+#define SCNi16 __INT16_FMTi__
+#define SCNd32 __INT32_FMTd__
+#define SCNi32 __INT32_FMTi__
+#define SCNd64 __INT64_FMTd__
+#define SCNi64 __INT64_FMTi__
+#define SCNd8 __INT8_FMTd__
+#define SCNi8 __INT8_FMTi__
+#define SCNdMAX __INTMAX_FMTd__
+#define SCNiMAX __INTMAX_FMTi__
+#define SCNdPTR __INTPTR_FMTd__
+#define SCNiPTR __INTPTR_FMTi__
+#define SCNdFAST16 __INT_FAST16_FMTd__
+#define SCNiFAST16 __INT_FAST16_FMTi__
+#define SCNdFAST32 __INT_FAST32_FMTd__
+#define SCNiFAST32 __INT_FAST32_FMTi__
+#define SCNdFAST64 __INT_FAST64_FMTd__
+#define SCNiFAST64 __INT_FAST64_FMTi__
+#define SCNdFAST8 __INT_FAST8_FMTd__
+#define SCNiFAST8 __INT_FAST8_FMTi__
+#define SCNdLEAST16 __INT_LEAST16_FMTd__
+#define SCNiLEAST16 __INT_LEAST16_FMTi__
+#define SCNdLEAST32 __INT_LEAST32_FMTd__
+#define SCNiLEAST32 __INT_LEAST32_FMTi__
+#define SCNdLEAST64 __INT_LEAST64_FMTd__
+#define SCNiLEAST64 __INT_LEAST64_FMTi__
+#define SCNdLEAST8 __INT_LEAST8_FMTd__
+#define SCNiLEAST8 __INT_LEAST8_FMTi__
+#define SCNo16 __UINT16_FMTo__
+#define SCNu16 __UINT16_FMTu__
+#define SCNx16 __UINT16_FMTx__
+#define SCNo32 __UINT32_FMTo__
+#define SCNu32 __UINT32_FMTu__
+#define SCNx32 __UINT32_FMTx__
+#define SCNo64 __UINT64_FMTo__
+#define SCNu64 __UINT64_FMTu__
+#define SCNx64 __UINT64_FMTx__
+#define SCNo8 __UINT8_FMTo__
+#define SCNu8 __UINT8_FMTu__
+#define SCNx8 __UINT8_FMTx__
+#define SCNoMAX __UINTMAX_FMTo__
+#define SCNuMAX __UINTMAX_FMTu__
+#define SCNxMAX __UINTMAX_FMTx__
+#define SCNoPTR __UINTPTR_FMTo__
+#define SCNuPTR __UINTPTR_FMTu__
+#define SCNxPTR __UINTPTR_FMTx__
+#define SCNoFAST16 __UINT_FAST16_FMTo__
+#define SCNuFAST16 __UINT_FAST16_FMTu__
+#define SCNxFAST16 __UINT_FAST16_FMTx__
+#define SCNoFAST32 __UINT_FAST32_FMTo__
+#define SCNuFAST32 __UINT_FAST32_FMTu__
+#define SCNxFAST32 __UINT_FAST32_FMTx__
+#define SCNoFAST64 __UINT_FAST64_FMTo__
+#define SCNuFAST64 __UINT_FAST64_FMTu__
+#define SCNxFAST64 __UINT_FAST64_FMTx__
+#define SCNoFAST8 __UINT_FAST8_FMTo__
+#define SCNuFAST8 __UINT_FAST8_FMTu__
+#define SCNxFAST8 __UINT_FAST8_FMTx__
+#define SCNoLEAST16 __UINT_LEAST16_FMTo__
+#define SCNuLEAST16 __UINT_LEAST16_FMTu__
+#define SCNxLEAST16 __UINT_LEAST16_FMTx__
+#define SCNoLEAST32 __UINT_LEAST32_FMTo__
+#define SCNuLEAST32 __UINT_LEAST32_FMTu__
+#define SCNxLEAST32 __UINT_LEAST32_FMTx__
+#define SCNoLEAST64 __UINT_LEAST64_FMTo__
+#define SCNuLEAST64 __UINT_LEAST64_FMTu__
+#define SCNxLEAST64 __UINT_LEAST64_FMTx__
+#define SCNoLEAST8 __UINT_LEAST8_FMTo__
+#define SCNuLEAST8 __UINT_LEAST8_FMTu__
+#define SCNxLEAST8 __UINT_LEAST8_FMTx__
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/basics/include/inttypes.h
+++ b/basics/include/inttypes.h
@@ -1,0 +1,10 @@
+#ifndef __wasm_basics_inttypes_h
+#define __wasm_basics_inttypes_h
+
+/*
+ * Include the real implementation, which is factored into a separate file so
+ * that it can be reused by other libc stdlib implementations.
+ */
+#include <__header_inttypes.h>
+
+#endif

--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -7,6 +7,7 @@
 #include <__header_bits_signal.h>
 #include <__header_dirent.h>
 #include <__header_fcntl.h>
+#include <__header_inttypes.h>
 #include <__header_netinet_in.h>
 #include <__header_poll.h>
 #include <__header_stdlib.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -1687,90 +1687,90 @@
 #define POSIX_FADV_SEQUENTIAL __WASI_ADVICE_SEQUENTIAL
 #define POSIX_FADV_WILLNEED __WASI_ADVICE_WILLNEED
 #define PRELIM 1
-#define PRIX16 "X"
-#define PRIX32 "X"
-#define PRIX64 __PRI64 "X"
-#define PRIX8 "X"
-#define PRIXFAST16 "X"
-#define PRIXFAST32 "X"
-#define PRIXFAST64 __PRI64 "X"
-#define PRIXFAST8 "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 __PRI64 "X"
-#define PRIXLEAST8 "X"
-#define PRIXMAX __PRI64 "X"
-#define PRIXPTR __PRIPTR "X"
-#define PRId16 "d"
-#define PRId32 "d"
-#define PRId64 __PRI64 "d"
-#define PRId8 "d"
-#define PRIdFAST16 "d"
-#define PRIdFAST32 "d"
-#define PRIdFAST64 __PRI64 "d"
-#define PRIdFAST8 "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 __PRI64 "d"
-#define PRIdLEAST8 "d"
-#define PRIdMAX __PRI64 "d"
-#define PRIdPTR __PRIPTR "d"
-#define PRIi16 "i"
-#define PRIi32 "i"
-#define PRIi64 __PRI64 "i"
-#define PRIi8 "i"
-#define PRIiFAST16 "i"
-#define PRIiFAST32 "i"
-#define PRIiFAST64 __PRI64 "i"
-#define PRIiFAST8 "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 __PRI64 "i"
-#define PRIiLEAST8 "i"
-#define PRIiMAX __PRI64 "i"
-#define PRIiPTR __PRIPTR "i"
-#define PRIo16 "o"
-#define PRIo32 "o"
-#define PRIo64 __PRI64 "o"
-#define PRIo8 "o"
-#define PRIoFAST16 "o"
-#define PRIoFAST32 "o"
-#define PRIoFAST64 __PRI64 "o"
-#define PRIoFAST8 "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 __PRI64 "o"
-#define PRIoLEAST8 "o"
-#define PRIoMAX __PRI64 "o"
-#define PRIoPTR __PRIPTR "o"
-#define PRIu16 "u"
-#define PRIu32 "u"
-#define PRIu64 __PRI64 "u"
-#define PRIu8 "u"
-#define PRIuFAST16 "u"
-#define PRIuFAST32 "u"
-#define PRIuFAST64 __PRI64 "u"
-#define PRIuFAST8 "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 __PRI64 "u"
-#define PRIuLEAST8 "u"
-#define PRIuMAX __PRI64 "u"
-#define PRIuPTR __PRIPTR "u"
-#define PRIx16 "x"
-#define PRIx32 "x"
-#define PRIx64 __PRI64 "x"
-#define PRIx8 "x"
-#define PRIxFAST16 "x"
-#define PRIxFAST32 "x"
-#define PRIxFAST64 __PRI64 "x"
-#define PRIxFAST8 "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 __PRI64 "x"
-#define PRIxLEAST8 "x"
-#define PRIxMAX __PRI64 "x"
-#define PRIxPTR __PRIPTR "x"
+#define PRIX16 __UINT16_FMTX__
+#define PRIX32 __UINT32_FMTX__
+#define PRIX64 __UINT64_FMTX__
+#define PRIX8 __UINT8_FMTX__
+#define PRIXFAST16 __UINT_FAST16_FMTX__
+#define PRIXFAST32 __UINT_FAST32_FMTX__
+#define PRIXFAST64 __UINT_FAST64_FMTX__
+#define PRIXFAST8 __UINT_FAST8_FMTX__
+#define PRIXLEAST16 __UINT_LEAST16_FMTX__
+#define PRIXLEAST32 __UINT_LEAST32_FMTX__
+#define PRIXLEAST64 __UINT_LEAST64_FMTX__
+#define PRIXLEAST8 __UINT_LEAST8_FMTX__
+#define PRIXMAX __UINTMAX_FMTX__
+#define PRIXPTR __UINTPTR_FMTX__
+#define PRId16 __INT16_FMTd__
+#define PRId32 __INT32_FMTd__
+#define PRId64 __INT64_FMTd__
+#define PRId8 __INT8_FMTd__
+#define PRIdFAST16 __INT_FAST16_FMTd__
+#define PRIdFAST32 __INT_FAST32_FMTd__
+#define PRIdFAST64 __INT_FAST64_FMTd__
+#define PRIdFAST8 __INT_FAST8_FMTd__
+#define PRIdLEAST16 __INT_LEAST16_FMTd__
+#define PRIdLEAST32 __INT_LEAST32_FMTd__
+#define PRIdLEAST64 __INT_LEAST64_FMTd__
+#define PRIdLEAST8 __INT_LEAST8_FMTd__
+#define PRIdMAX __INTMAX_FMTd__
+#define PRIdPTR __INTPTR_FMTd__
+#define PRIi16 __INT16_FMTi__
+#define PRIi32 __INT32_FMTi__
+#define PRIi64 __INT64_FMTi__
+#define PRIi8 __INT8_FMTi__
+#define PRIiFAST16 __INT_FAST16_FMTi__
+#define PRIiFAST32 __INT_FAST32_FMTi__
+#define PRIiFAST64 __INT_FAST64_FMTi__
+#define PRIiFAST8 __INT_FAST8_FMTi__
+#define PRIiLEAST16 __INT_LEAST16_FMTi__
+#define PRIiLEAST32 __INT_LEAST32_FMTi__
+#define PRIiLEAST64 __INT_LEAST64_FMTi__
+#define PRIiLEAST8 __INT_LEAST8_FMTi__
+#define PRIiMAX __INTMAX_FMTi__
+#define PRIiPTR __INTPTR_FMTi__
+#define PRIo16 __UINT16_FMTo__
+#define PRIo32 __UINT32_FMTo__
+#define PRIo64 __UINT64_FMTo__
+#define PRIo8 __UINT8_FMTo__
+#define PRIoFAST16 __UINT_FAST16_FMTo__
+#define PRIoFAST32 __UINT_FAST32_FMTo__
+#define PRIoFAST64 __UINT_FAST64_FMTo__
+#define PRIoFAST8 __UINT_FAST8_FMTo__
+#define PRIoLEAST16 __UINT_LEAST16_FMTo__
+#define PRIoLEAST32 __UINT_LEAST32_FMTo__
+#define PRIoLEAST64 __UINT_LEAST64_FMTo__
+#define PRIoLEAST8 __UINT_LEAST8_FMTo__
+#define PRIoMAX __UINTMAX_FMTo__
+#define PRIoPTR __UINTPTR_FMTo__
+#define PRIu16 __UINT16_FMTu__
+#define PRIu32 __UINT32_FMTu__
+#define PRIu64 __UINT64_FMTu__
+#define PRIu8 __UINT8_FMTu__
+#define PRIuFAST16 __UINT_FAST16_FMTu__
+#define PRIuFAST32 __UINT_FAST32_FMTu__
+#define PRIuFAST64 __UINT_FAST64_FMTu__
+#define PRIuFAST8 __UINT_FAST8_FMTu__
+#define PRIuLEAST16 __UINT_LEAST16_FMTu__
+#define PRIuLEAST32 __UINT_LEAST32_FMTu__
+#define PRIuLEAST64 __UINT_LEAST64_FMTu__
+#define PRIuLEAST8 __UINT_LEAST8_FMTu__
+#define PRIuMAX __UINTMAX_FMTu__
+#define PRIuPTR __UINTPTR_FMTu__
+#define PRIx16 __UINT16_FMTx__
+#define PRIx32 __UINT32_FMTx__
+#define PRIx64 __UINT64_FMTx__
+#define PRIx8 __UINT8_FMTx__
+#define PRIxFAST16 __UINT_FAST16_FMTx__
+#define PRIxFAST32 __UINT_FAST32_FMTx__
+#define PRIxFAST64 __UINT_FAST64_FMTx__
+#define PRIxFAST8 __UINT_FAST8_FMTx__
+#define PRIxLEAST16 __UINT_LEAST16_FMTx__
+#define PRIxLEAST32 __UINT_LEAST32_FMTx__
+#define PRIxLEAST64 __UINT_LEAST64_FMTx__
+#define PRIxLEAST8 __UINT_LEAST8_FMTx__
+#define PRIxMAX __UINTMAX_FMTx__
+#define PRIxPTR __UINTPTR_FMTx__
 #define PTRBITS (sizeof(char *) * 8)
 #define PTRDIFF_MAX INT32_MAX
 #define PTRDIFF_MIN INT32_MIN
@@ -1881,76 +1881,76 @@
 #define SB 250
 #define SCHAR_MAX 127
 #define SCHAR_MIN (-128)
-#define SCNd16 "hd"
-#define SCNd32 "d"
-#define SCNd64 __PRI64 "d"
-#define SCNd8 "hhd"
-#define SCNdFAST16 "d"
-#define SCNdFAST32 "d"
-#define SCNdFAST64 __PRI64 "d"
-#define SCNdFAST8 "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 __PRI64 "d"
-#define SCNdLEAST8 "hhd"
-#define SCNdMAX __PRI64 "d"
-#define SCNdPTR __PRIPTR "d"
-#define SCNi16 "hi"
-#define SCNi32 "i"
-#define SCNi64 __PRI64 "i"
-#define SCNi8 "hhi"
-#define SCNiFAST16 "i"
-#define SCNiFAST32 "i"
-#define SCNiFAST64 __PRI64 "i"
-#define SCNiFAST8 "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 __PRI64 "i"
-#define SCNiLEAST8 "hhi"
-#define SCNiMAX __PRI64 "i"
-#define SCNiPTR __PRIPTR "i"
-#define SCNo16 "ho"
-#define SCNo32 "o"
-#define SCNo64 __PRI64 "o"
-#define SCNo8 "hho"
-#define SCNoFAST16 "o"
-#define SCNoFAST32 "o"
-#define SCNoFAST64 __PRI64 "o"
-#define SCNoFAST8 "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 __PRI64 "o"
-#define SCNoLEAST8 "hho"
-#define SCNoMAX __PRI64 "o"
-#define SCNoPTR __PRIPTR "o"
-#define SCNu16 "hu"
-#define SCNu32 "u"
-#define SCNu64 __PRI64 "u"
-#define SCNu8 "hhu"
-#define SCNuFAST16 "u"
-#define SCNuFAST32 "u"
-#define SCNuFAST64 __PRI64 "u"
-#define SCNuFAST8 "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 __PRI64 "u"
-#define SCNuLEAST8 "hhu"
-#define SCNuMAX __PRI64 "u"
-#define SCNuPTR __PRIPTR "u"
-#define SCNx16 "hx"
-#define SCNx32 "x"
-#define SCNx64 __PRI64 "x"
-#define SCNx8 "hhx"
-#define SCNxFAST16 "x"
-#define SCNxFAST32 "x"
-#define SCNxFAST64 __PRI64 "x"
-#define SCNxFAST8 "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 __PRI64 "x"
-#define SCNxLEAST8 "hhx"
-#define SCNxMAX __PRI64 "x"
-#define SCNxPTR __PRIPTR "x"
+#define SCNd16 __INT16_FMTd__
+#define SCNd32 __INT32_FMTd__
+#define SCNd64 __INT64_FMTd__
+#define SCNd8 __INT8_FMTd__
+#define SCNdFAST16 __INT_FAST16_FMTd__
+#define SCNdFAST32 __INT_FAST32_FMTd__
+#define SCNdFAST64 __INT_FAST64_FMTd__
+#define SCNdFAST8 __INT_FAST8_FMTd__
+#define SCNdLEAST16 __INT_LEAST16_FMTd__
+#define SCNdLEAST32 __INT_LEAST32_FMTd__
+#define SCNdLEAST64 __INT_LEAST64_FMTd__
+#define SCNdLEAST8 __INT_LEAST8_FMTd__
+#define SCNdMAX __INTMAX_FMTd__
+#define SCNdPTR __INTPTR_FMTd__
+#define SCNi16 __INT16_FMTi__
+#define SCNi32 __INT32_FMTi__
+#define SCNi64 __INT64_FMTi__
+#define SCNi8 __INT8_FMTi__
+#define SCNiFAST16 __INT_FAST16_FMTi__
+#define SCNiFAST32 __INT_FAST32_FMTi__
+#define SCNiFAST64 __INT_FAST64_FMTi__
+#define SCNiFAST8 __INT_FAST8_FMTi__
+#define SCNiLEAST16 __INT_LEAST16_FMTi__
+#define SCNiLEAST32 __INT_LEAST32_FMTi__
+#define SCNiLEAST64 __INT_LEAST64_FMTi__
+#define SCNiLEAST8 __INT_LEAST8_FMTi__
+#define SCNiMAX __INTMAX_FMTi__
+#define SCNiPTR __INTPTR_FMTi__
+#define SCNo16 __UINT16_FMTo__
+#define SCNo32 __UINT32_FMTo__
+#define SCNo64 __UINT64_FMTo__
+#define SCNo8 __UINT8_FMTo__
+#define SCNoFAST16 __UINT_FAST16_FMTo__
+#define SCNoFAST32 __UINT_FAST32_FMTo__
+#define SCNoFAST64 __UINT_FAST64_FMTo__
+#define SCNoFAST8 __UINT_FAST8_FMTo__
+#define SCNoLEAST16 __UINT_LEAST16_FMTo__
+#define SCNoLEAST32 __UINT_LEAST32_FMTo__
+#define SCNoLEAST64 __UINT_LEAST64_FMTo__
+#define SCNoLEAST8 __UINT_LEAST8_FMTo__
+#define SCNoMAX __UINTMAX_FMTo__
+#define SCNoPTR __UINTPTR_FMTo__
+#define SCNu16 __UINT16_FMTu__
+#define SCNu32 __UINT32_FMTu__
+#define SCNu64 __UINT64_FMTu__
+#define SCNu8 __UINT8_FMTu__
+#define SCNuFAST16 __UINT_FAST16_FMTu__
+#define SCNuFAST32 __UINT_FAST32_FMTu__
+#define SCNuFAST64 __UINT_FAST64_FMTu__
+#define SCNuFAST8 __UINT_FAST8_FMTu__
+#define SCNuLEAST16 __UINT_LEAST16_FMTu__
+#define SCNuLEAST32 __UINT_LEAST32_FMTu__
+#define SCNuLEAST64 __UINT_LEAST64_FMTu__
+#define SCNuLEAST8 __UINT_LEAST8_FMTu__
+#define SCNuMAX __UINTMAX_FMTu__
+#define SCNuPTR __UINTPTR_FMTu__
+#define SCNx16 __UINT16_FMTx__
+#define SCNx32 __UINT32_FMTx__
+#define SCNx64 __UINT64_FMTx__
+#define SCNx8 __UINT8_FMTx__
+#define SCNxFAST16 __UINT_FAST16_FMTx__
+#define SCNxFAST32 __UINT_FAST32_FMTx__
+#define SCNxFAST64 __UINT_FAST64_FMTx__
+#define SCNxFAST8 __UINT_FAST8_FMTx__
+#define SCNxLEAST16 __UINT_LEAST16_FMTx__
+#define SCNxLEAST32 __UINT_LEAST32_FMTx__
+#define SCNxLEAST64 __UINT_LEAST64_FMTx__
+#define SCNxLEAST8 __UINT_LEAST8_FMTx__
+#define SCNxMAX __UINTMAX_FMTx__
+#define SCNxPTR __UINTPTR_FMTx__
 #define SE 240
 #define SEEK_CUR __WASI_WHENCE_CUR
 #define SEEK_END __WASI_WHENCE_END
@@ -3193,8 +3193,6 @@
 #define __PDP_ENDIAN 3412
 #define __POINTER_WIDTH__ 32
 #define __PRAGMA_REDEFINE_EXTNAME 1
-#define __PRI64 "ll"
-#define __PRIPTR ""
 #define __PTRDIFF_FMTd__ "ld"
 #define __PTRDIFF_FMTi__ "li"
 #define __PTRDIFF_MAX__ 2147483647L
@@ -3617,6 +3615,7 @@
 #define __wasm___functions_malloc_h 
 #define __wasm___functions_memcpy_h 
 #define __wasm_basics___errno_h 
+#define __wasm_basics___include_inttypes_h 
 #define __wasm_basics___macro_PAGESIZE_h 
 #define __wasm_basics___struct_stat_h 
 #define __wasm_basics___struct_timespec_h 

--- a/libc-top-half/musl/include/inttypes.h
+++ b/libc-top-half/musl/include/inttypes.h
@@ -1,6 +1,7 @@
 #ifndef _INTTYPES_H
 #define _INTTYPES_H
 
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -223,6 +224,9 @@ uintmax_t wcstoumax(const wchar_t *__restrict, wchar_t **__restrict, int);
 
 #ifdef __cplusplus
 }
+#endif
+#else
+#include <__header_inttypes.h>
 #endif
 
 #endif


### PR DESCRIPTION
Musl's generic definitions for PRIxPTR and several others in
<inttypes.h> are incorrect for wasm, so introduce a new <inttypes.h>
and <__header_inttypes.h> in the basics module using compiler-provided
definitions.

Fixes #13.