### PR TITLE
Fix floatscan no long double usage

### DIFF
--- a/libc-top-half/headers/private/printscan.h
+++ b/libc-top-half/headers/private/printscan.h
@@ -37,6 +37,12 @@ typedef double long_double;
 #define LDBL_MAX_10_EXP DBL_MAX_10_EXP
 #undef frexpl
 #define frexpl(x, exp) frexp(x, exp)
+#undef copysignl
+#define copysignl(x, y) copysign(x, y)
+#undef fmodl
+#define fmodl(x, y) fmod(x, y)
+#undef scalbnl
+#define scalbnl(arg, exp) scalbn(arg, exp)
 __attribute__((__cold__, __noreturn__))
 static void long_double_not_supported(void) {
     void abort(void) __attribute__((__noreturn__));

--- a/libc-top-half/musl/src/internal/floatscan.c
+++ b/libc-top-half/musl/src/internal/floatscan.c
@@ -301,8 +301,13 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 
 	/* Calculate bias term to force rounding, move out lower bits */
 	if (bits < LDBL_MANT_DIG) {
-		bias = copysignl(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
-		frac = fmodl(y, scalbn(1, LDBL_MANT_DIG-bits));
+#if defined(__wasilibc_printscan_no_long_double)
+		bias = copysign(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
+		frac = fmod(y, scalbn(1, LDBL_MANT_DIG-bits));
+#else
+        bias = copysignl(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
+        frac = fmodl(y, scalbn(1, LDBL_MANT_DIG-bits));
+#endif
 		y -= frac;
 		y += bias;
 	}
@@ -320,7 +325,11 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 			else
 				frac += 0.75*sign;
 		}
-		if (LDBL_MANT_DIG-bits >= 2 && !fmodl(frac, 1))
+#if defined(__wasilibc_printscan_no_long_double)
+		if (LDBL_MANT_DIG-bits >= 2 && !fmod(frac, 1))
+#else
+        if (LDBL_MANT_DIG-bits >= 2 && !fmodl(frac, 1))
+#endif
 			frac++;
 	}
 
@@ -338,7 +347,11 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 			errno = ERANGE;
 	}
 
-	return scalbnl(y, e2);
+#if defined(__wasilibc_printscan_no_long_double)
+	return scalbn(y, e2);
+#else
+    return scalbnl(y, e2);
+#endif
 }
 
 #if defined(__wasilibc_printscan_no_long_double)
@@ -451,7 +464,11 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 	}
 
 	if (bits < LDBL_MANT_DIG)
-		bias = copysignl(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
+#if defined(__wasilibc_printscan_no_long_double)
+		bias = copysign(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
+#else
+        bias = copysignl(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
+#endif
 
 	if (bits<32 && y && !(x&1)) x++, y=0;
 
@@ -464,7 +481,11 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 
 	if (!y) errno = ERANGE;
 
-	return scalbnl(y, e2);
+#if defined(__wasilibc_printscan_no_long_double)
+	return scalbn(y, e2);
+#else
+    return scalbnl(y, e2);
+#endif
 }
 
 #if defined(__wasilibc_printscan_no_long_double)

--- a/libc-top-half/musl/src/internal/floatscan.c
+++ b/libc-top-half/musl/src/internal/floatscan.c
@@ -290,7 +290,7 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 #if defined(__wasilibc_printscan_no_long_double)
 		y = 1000000000.0 * y + x[a+i & MASK];
 #else
-        y = 1000000000.0L * y + x[a+i & MASK];
+		y = 1000000000.0L * y + x[a+i & MASK];
 #endif
 	}
 

--- a/libc-top-half/musl/src/internal/floatscan.c
+++ b/libc-top-half/musl/src/internal/floatscan.c
@@ -305,8 +305,8 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 		bias = copysign(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
 		frac = fmod(y, scalbn(1, LDBL_MANT_DIG-bits));
 #else
-        bias = copysignl(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
-        frac = fmodl(y, scalbn(1, LDBL_MANT_DIG-bits));
+		bias = copysignl(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
+		frac = fmodl(y, scalbn(1, LDBL_MANT_DIG-bits));
 #endif
 		y -= frac;
 		y += bias;
@@ -328,7 +328,7 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 #if defined(__wasilibc_printscan_no_long_double)
 		if (LDBL_MANT_DIG-bits >= 2 && !fmod(frac, 1))
 #else
-        if (LDBL_MANT_DIG-bits >= 2 && !fmodl(frac, 1))
+		if (LDBL_MANT_DIG-bits >= 2 && !fmodl(frac, 1))
 #endif
 			frac++;
 	}
@@ -350,7 +350,7 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 #if defined(__wasilibc_printscan_no_long_double)
 	return scalbn(y, e2);
 #else
-    return scalbnl(y, e2);
+	return scalbnl(y, e2);
 #endif
 }
 
@@ -467,7 +467,7 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 #if defined(__wasilibc_printscan_no_long_double)
 		bias = copysign(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
 #else
-        bias = copysignl(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
+		bias = copysignl(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
 #endif
 
 	if (bits<32 && y && !(x&1)) x++, y=0;
@@ -484,7 +484,7 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 #if defined(__wasilibc_printscan_no_long_double)
 	return scalbn(y, e2);
 #else
-    return scalbnl(y, e2);
+	return scalbnl(y, e2);
 #endif
 }
 

--- a/libc-top-half/musl/src/internal/floatscan.c
+++ b/libc-top-half/musl/src/internal/floatscan.c
@@ -287,7 +287,11 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 	/* Assemble desired bits into floating point variable */
 	for (y=i=0; i<LD_B1B_DIG; i++) {
 		if ((a+i & MASK)==z) x[(z=(z+1 & MASK))-1] = 0;
-		y = 1000000000.0L * y + x[a+i & MASK];
+#if defined(__wasilibc_printscan_no_long_double)
+		y = 1000000000.0 * y + x[a+i & MASK];
+#else
+        y = 1000000000.0L * y + x[a+i & MASK];
+#endif
 	}
 
 	y *= sign;
@@ -301,13 +305,8 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 
 	/* Calculate bias term to force rounding, move out lower bits */
 	if (bits < LDBL_MANT_DIG) {
-#if defined(__wasilibc_printscan_no_long_double)
-		bias = copysign(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
-		frac = fmod(y, scalbn(1, LDBL_MANT_DIG-bits));
-#else
 		bias = copysignl(scalbn(1, 2*LDBL_MANT_DIG-bits-1), y);
 		frac = fmodl(y, scalbn(1, LDBL_MANT_DIG-bits));
-#endif
 		y -= frac;
 		y += bias;
 	}
@@ -325,11 +324,7 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 			else
 				frac += 0.75*sign;
 		}
-#if defined(__wasilibc_printscan_no_long_double)
-		if (LDBL_MANT_DIG-bits >= 2 && !fmod(frac, 1))
-#else
 		if (LDBL_MANT_DIG-bits >= 2 && !fmodl(frac, 1))
-#endif
 			frac++;
 	}
 
@@ -347,11 +342,7 @@ static long double decfloat(FILE *f, int c, int bits, int emin, int sign, int po
 			errno = ERANGE;
 	}
 
-#if defined(__wasilibc_printscan_no_long_double)
-	return scalbn(y, e2);
-#else
 	return scalbnl(y, e2);
-#endif
 }
 
 #if defined(__wasilibc_printscan_no_long_double)
@@ -464,11 +455,7 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 	}
 
 	if (bits < LDBL_MANT_DIG)
-#if defined(__wasilibc_printscan_no_long_double)
-		bias = copysign(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
-#else
 		bias = copysignl(scalbn(1, 32+LDBL_MANT_DIG-bits-1), sign);
-#endif
 
 	if (bits<32 && y && !(x&1)) x++, y=0;
 
@@ -481,11 +468,7 @@ static long double hexfloat(FILE *f, int bits, int emin, int sign, int pok)
 
 	if (!y) errno = ERANGE;
 
-#if defined(__wasilibc_printscan_no_long_double)
-	return scalbn(y, e2);
-#else
 	return scalbnl(y, e2);
-#endif
 }
 
 #if defined(__wasilibc_printscan_no_long_double)

--- a/libc-top-half/musl/src/stdio/vfprintf.c
+++ b/libc-top-half/musl/src/stdio/vfprintf.c
@@ -239,7 +239,7 @@ static int fmt_fp(FILE *f, long double y, int w, int p, int fl, int t)
 #if defined(__wasilibc_printscan_no_long_double)
 	y = frexpl(y, &e2) * 2;
 #else
-    y = frexp(y, &e2) * 2;
+	y = frexp(y, &e2) * 2;
 #endif
 	if (y) e2--;
 

--- a/libc-top-half/musl/src/stdio/vfprintf.c
+++ b/libc-top-half/musl/src/stdio/vfprintf.c
@@ -236,11 +236,7 @@ static int fmt_fp(FILE *f, long double y, int w, int p, int fl, int t)
 		return MAX(w, 3+pl);
 	}
 
-#if defined(__wasilibc_printscan_no_long_double)
-	y = frexp(y, &e2) * 2;
-#else
 	y = frexpl(y, &e2) * 2;
-#endif
 	if (y) e2--;
 
 	if ((t|32)=='a') {

--- a/libc-top-half/musl/src/stdio/vfprintf.c
+++ b/libc-top-half/musl/src/stdio/vfprintf.c
@@ -236,7 +236,11 @@ static int fmt_fp(FILE *f, long double y, int w, int p, int fl, int t)
 		return MAX(w, 3+pl);
 	}
 
+#if defined(__wasilibc_printscan_no_long_double)
 	y = frexpl(y, &e2) * 2;
+#else
+    y = frexp(y, &e2) * 2;
+#endif
 	if (y) e2--;
 
 	if ((t|32)=='a') {

--- a/libc-top-half/musl/src/stdio/vfprintf.c
+++ b/libc-top-half/musl/src/stdio/vfprintf.c
@@ -237,9 +237,9 @@ static int fmt_fp(FILE *f, long double y, int w, int p, int fl, int t)
 	}
 
 #if defined(__wasilibc_printscan_no_long_double)
-	y = frexpl(y, &e2) * 2;
-#else
 	y = frexp(y, &e2) * 2;
+#else
+	y = frexpl(y, &e2) * 2;
 #endif
 	if (y) e2--;
 


### PR DESCRIPTION
In the current version of `libc-printscan-no-long-double` long double could still appear by using functions with suffix `l` that receive long double parameters. So in the result binary, functions like __extenddftf2 will be generated.