### PR TITLE
Make the strerror message for ESUCCESS (0) be "Success".

### DIFF
--- a/libc-top-half/musl/src/errno/__strerror.h
+++ b/libc-top-half/musl/src/errno/__strerror.h
@@ -4,6 +4,10 @@
  * macro E() along with double-inclusion is used to ensure that ordering
  * of the strings remains synchronized. */
 
+#ifdef __wasilibc_unmodified_upstream // Print "Success" for ESUCCESS.
+#else
+E(0,            "Success")
+#endif
 E(EILSEQ,       "Illegal byte sequence")
 E(EDOM,         "Domain error")
 E(ERANGE,       "Result not representable")
@@ -125,4 +129,8 @@ E(EMULTIHOP,    "Multihop attempted")
 E(ENOTCAPABLE,  "Capabilities insufficient")
 #endif
 
+#ifdef __wasilibc_unmodified_upstream // Print "Success" for ESUCCESS.
 E(0,            "No error information")
+#else
+E(UCHAR_MAX,    "No error information")
+#endif

--- a/libc-top-half/musl/src/errno/strerror.c
+++ b/libc-top-half/musl/src/errno/strerror.c
@@ -23,7 +23,11 @@ char *__strerror_l(int e, locale_t loc)
 		if (e==109) e=-1;
 		else if (e==EDQUOT) e=109;
 	}
+#ifdef __wasilibc_unmodified_upstream // Print "Success" for ESUCCESS.
 	for (i=0; errid[i] && errid[i] != e; i++);
+#else
+	for (i=0; errid[i] != UCHAR_MAX && errid[i] != e; i++);
+#endif
 	for (s=errmsg; i; s++, i--) for (; *s; s++);
 	return (char *)LCTRANS(s, LC_MESSAGES, loc);
 }


### PR DESCRIPTION
Previously it was "No error information", which was indistinguishable
from an unrecognized errno value.