### PR TITLE
Add vfwprintf.c to the printscan list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
 MUSL_PRINTSCAN_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/internal/floatscan.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdio/vfprintf.c \
+    $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdio/vfwprintf.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdio/vfscanf.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdlib/strtod.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdlib/wcstod.c

--- a/libc-top-half/musl/src/stdio/vfwprintf.c
+++ b/libc-top-half/musl/src/stdio/vfwprintf.c
@@ -355,9 +355,11 @@ static int wprintf_core(FILE *f, const wchar_t *fmt, va_list *ap, union arg *nl_
 			sizeprefix[(t|32)-'a'], t);
 
 		switch (t|32) {
+#if !defined(__wasilibc_printscan_no_floating_point)
 		case 'a': case 'e': case 'f': case 'g':
 			l = fprintf(f, charfmt, w, p, arg.f);
 			break;
+#endif
 		case 'd': case 'i': case 'o': case 'u': case 'x': case 'p':
 			l = fprintf(f, charfmt, w, p, arg.i);
 			break;


### PR DESCRIPTION
This causes the build to produce no-long-double and no-floating-point
versions of this file, following what is done for vfprintf.c.