### PR TITLE
Disable unused fields in FILE and __libc.

### DIFF
--- a/libc-top-half/musl/src/internal/libc.h
+++ b/libc-top-half/musl/src/internal/libc.h
@@ -18,14 +18,26 @@ struct tls_module {
 };
 
 struct __libc {
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	int can_do_threads;
 	int threaded;
+#endif
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't currently use any code that needs "secure" mode
 	int secure;
+#endif
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	volatile int threads_minus_1;
+#endif
+#ifdef __wasilibc_unmodified_upstream // WASI has no auxv
 	size_t *auxv;
+#endif
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	struct tls_module *tls_head;
 	size_t tls_size, tls_align, tls_cnt;
+#endif
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't get the page size from auxv
 	size_t page_size;
+#endif
 	struct __locale_struct global_locale;
 #if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 #else

--- a/libc-top-half/musl/src/internal/stdio_impl.h
+++ b/libc-top-half/musl/src/internal/stdio_impl.h
@@ -30,7 +30,9 @@ struct _IO_FILE {
 	unsigned char *rpos, *rend;
 	int (*close)(FILE *);
 	unsigned char *wend, *wpos;
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't need backwards-compatibility fields.
 	unsigned char *mustbezero_1;
+#endif
 	unsigned char *wbase;
 	size_t (*read)(FILE *, unsigned char *, size_t);
 	size_t (*write)(FILE *, const unsigned char *, size_t);
@@ -39,18 +41,28 @@ struct _IO_FILE {
 	size_t buf_size;
 	FILE *prev, *next;
 	int fd;
+#ifdef __wasilibc_unmodified_upstream // WASI has no popen
 	int pipe_pid;
+#endif
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	long lockcount;
+#endif
 	int mode;
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	volatile int lock;
+#endif
 	int lbf;
 	void *cookie;
 	off_t off;
 	char *getln_buf;
+#ifdef __wasilibc_unmodified_upstream // WASI doesn't need backwards-compatibility fields.
 	void *mustbezero_2;
+#endif
 	unsigned char *shend;
 	off_t shlim, shcnt;
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	FILE *prev_locked, *next_locked;
+#endif
 	struct __locale_struct *locale;
 };
 

--- a/libc-top-half/musl/src/stdio/__fdopen.c
+++ b/libc-top-half/musl/src/stdio/__fdopen.c
@@ -74,7 +74,9 @@ FILE *__fdopen(int fd, const char *mode)
 	f->seek = __stdio_seek;
 	f->close = __stdio_close;
 
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (!libc.threaded) f->lock = -1;
+#endif
 
 	/* Add new FILE to open file list */
 	return __ofl_add(f);

--- a/libc-top-half/musl/src/stdio/__fopen_rb_ca.c
+++ b/libc-top-half/musl/src/stdio/__fopen_rb_ca.c
@@ -24,7 +24,9 @@ FILE *__fopen_rb_ca(const char *filename, FILE *f, unsigned char *buf, size_t le
 	f->read = __stdio_read;
 	f->seek = __stdio_seek;
 	f->close = __stdio_close;
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	f->lock = -1;
+#endif
 
 	return f;
 }

--- a/libc-top-half/musl/src/stdio/fmemopen.c
+++ b/libc-top-half/musl/src/stdio/fmemopen.c
@@ -121,7 +121,9 @@ FILE *fmemopen(void *restrict buf, size_t size, const char *restrict mode)
 	f->f.seek = mseek;
 	f->f.close = mclose;
 
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (!libc.threaded) f->f.lock = -1;
+#endif
 
 	return __ofl_add(&f->f);
 }

--- a/libc-top-half/musl/src/stdio/open_memstream.c
+++ b/libc-top-half/musl/src/stdio/open_memstream.c
@@ -93,7 +93,9 @@ FILE *open_memstream(char **bufp, size_t *sizep)
 	f->f.close = ms_close;
 	f->f.mode = -1;
 
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (!libc.threaded) f->f.lock = -1;
+#endif
 
 	return __ofl_add(&f->f);
 }

--- a/libc-top-half/musl/src/stdio/open_wmemstream.c
+++ b/libc-top-half/musl/src/stdio/open_wmemstream.c
@@ -94,7 +94,9 @@ FILE *open_wmemstream(wchar_t **bufp, size_t *sizep)
 	f->f.seek = wms_seek;
 	f->f.close = wms_close;
 
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (!libc.threaded) f->f.lock = -1;
+#endif
 
 	fwide(&f->f, 1);
 

--- a/libc-top-half/musl/src/stdio/stderr.c
+++ b/libc-top-half/musl/src/stdio/stderr.c
@@ -12,7 +12,9 @@ hidden FILE __stderr_FILE = {
 	.write = __stdio_write,
 	.seek = __stdio_seek,
 	.close = __stdio_close,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	.lock = -1,
+#endif
 };
 FILE *const stderr = &__stderr_FILE;
 FILE *volatile __stderr_used = &__stderr_FILE;

--- a/libc-top-half/musl/src/stdio/stdin.c
+++ b/libc-top-half/musl/src/stdio/stdin.c
@@ -11,7 +11,9 @@ hidden FILE __stdin_FILE = {
 	.read = __stdio_read,
 	.seek = __stdio_seek,
 	.close = __stdio_close,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	.lock = -1,
+#endif
 };
 FILE *const stdin = &__stdin_FILE;
 FILE *volatile __stdin_used = &__stdin_FILE;

--- a/libc-top-half/musl/src/stdio/stdout.c
+++ b/libc-top-half/musl/src/stdio/stdout.c
@@ -12,7 +12,9 @@ hidden FILE __stdout_FILE = {
 	.write = __stdout_write,
 	.seek = __stdio_seek,
 	.close = __stdio_close,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	.lock = -1,
+#endif
 };
 FILE *const stdout = &__stdout_FILE;
 FILE *volatile __stdout_used = &__stdout_FILE;

--- a/libc-top-half/musl/src/stdio/vdprintf.c
+++ b/libc-top-half/musl/src/stdio/vdprintf.c
@@ -10,7 +10,9 @@ int vdprintf(int fd, const char *restrict fmt, va_list ap)
 	FILE f = {
 		.fd = fd, .lbf = EOF, .write = wrap_write,
 		.buf = (void *)fmt, .buf_size = 0,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 		.lock = -1
+#endif
 	};
 	return vfprintf(&f, fmt, ap);
 }

--- a/libc-top-half/musl/src/stdio/vsnprintf.c
+++ b/libc-top-half/musl/src/stdio/vsnprintf.c
@@ -40,7 +40,9 @@ int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
 	FILE f = {
 		.lbf = EOF,
 		.write = sn_write,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 		.lock = -1,
+#endif
 		.buf = buf,
 		.cookie = &c,
 	};

--- a/libc-top-half/musl/src/stdio/vsscanf.c
+++ b/libc-top-half/musl/src/stdio/vsscanf.c
@@ -9,7 +9,11 @@ int vsscanf(const char *restrict s, const char *restrict fmt, va_list ap)
 {
 	FILE f = {
 		.buf = (void *)s, .cookie = (void *)s,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 		.read = do_read, .lock = -1
+#else
+		.read = do_read
+#endif
 	};
 	return vfscanf(&f, fmt, ap);
 }

--- a/libc-top-half/musl/src/stdio/vswprintf.c
+++ b/libc-top-half/musl/src/stdio/vswprintf.c
@@ -42,7 +42,9 @@ int vswprintf(wchar_t *restrict s, size_t n, const wchar_t *restrict fmt, va_lis
 	FILE f = {
 		.lbf = EOF,
 		.write = sw_write,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 		.lock = -1,
+#endif
 		.buf = buf,
 		.buf_size = sizeof buf,
 		.cookie = &c,

--- a/libc-top-half/musl/src/stdio/vswscanf.c
+++ b/libc-top-half/musl/src/stdio/vswscanf.c
@@ -30,7 +30,11 @@ int vswscanf(const wchar_t *restrict s, const wchar_t *restrict fmt, va_list ap)
 	FILE f = {
 		.buf = buf, .buf_size = sizeof buf,
 		.cookie = (void *)s,
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 		.read = wstring_read, .lock = -1
+#else
+		.read = wstring_read
+#endif
 	};
 	return vfwscanf(&f, fmt, ap);
 }

--- a/libc-top-half/musl/src/stdlib/wcstod.c
+++ b/libc-top-half/musl/src/stdlib/wcstod.c
@@ -44,7 +44,9 @@ static long double wcstox(const wchar_t *s, wchar_t **p, int prec)
 	f.rpos = f.rend = 0;
 	f.buf = buf + 4;
 	f.buf_size = sizeof buf - 4;
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	f.lock = -1;
+#endif
 	f.read = do_read;
 	while (iswspace(*t)) t++;
 	f.cookie = (void *)t;

--- a/libc-top-half/musl/src/stdlib/wcstol.c
+++ b/libc-top-half/musl/src/stdlib/wcstol.c
@@ -38,7 +38,9 @@ static unsigned long long wcstox(const wchar_t *s, wchar_t **p, int base, unsign
 	f.rpos = f.rend = 0;
 	f.buf = buf + 4;
 	f.buf_size = sizeof buf - 4;
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	f.lock = -1;
+#endif
 	f.read = do_read;
 	while (iswspace(*t)) t++;
 	f.cookie = (void *)t;


### PR DESCRIPTION
Some of these fields are only needed for threads, some are not needed at
all. Removing them helps prevent code from accidentally using them, such
as when we merge in new musl versions.
