### PR TITLE
Declare getentropy in <sys/random.h>

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -80,6 +80,7 @@ __fwritex
 __fwriting
 __get_locale
 __getdelim
+__getentropy
 __getopt_msg
 __gmtime_r
 __hwcap

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -711,8 +711,6 @@
 #define GLOB_NOSPACE 1
 #define GLOB_NOSYS 4
 #define GLOB_PERIOD 0x80
-#define GRND_NONBLOCK 0x0001
-#define GRND_RANDOM 0x0002
 #define GROUP_FILTER_SIZE(numsrc) (sizeof(struct group_filter) - sizeof(struct sockaddr_storage) + (numsrc) * sizeof(struct sockaddr_storage))
 #define HFIXEDSZ NS_HFIXEDSZ
 #define HIBITL MINLONG

--- a/libc-bottom-half/sources/getentropy.c
+++ b/libc-bottom-half/sources/getentropy.c
@@ -6,7 +6,7 @@
 #error With threads support, getentropy is not intended to be a cancellation point.
 #endif
 
-int getentropy(void *buffer, size_t len) {
+int __getentropy(void *buffer, size_t len) {
     if (len > 256) {
         errno = EIO;
         return -1;
@@ -21,3 +21,4 @@ int getentropy(void *buffer, size_t len) {
 
     return 0;
 }
+extern __typeof(__getentropy) getentropy __attribute__((weak, alias("__getentropy")));

--- a/libc-top-half/musl/include/sys/random.h
+++ b/libc-top-half/musl/include/sys/random.h
@@ -4,6 +4,7 @@
 extern "C" {
 #endif
 
+#ifdef __wasilibc_unmodified_upstream /* WASI has no getrandom, but it does have getentropy */
 #define __NEED_size_t
 #define __NEED_ssize_t
 #include <bits/alltypes.h>
@@ -12,6 +13,12 @@ extern "C" {
 #define GRND_RANDOM	0x0002
 
 ssize_t getrandom(void *, size_t, unsigned);
+#else
+#define __NEED_size_t
+#include <bits/alltypes.h>
+
+int getentropy(void *, size_t);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some systems, such as Darwin, only declare getentropy in <sys/random.h>,
so declare it there on WASI too for compatibility.

Also, give getentropy the underscore-prefix/weak-symbol treatment, as
it's not a standard-reserved identifier.

