### PR TITLE
Say "wasm32-wasi" rather than "wasm32-unknown-wasi".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ LIBC_TOP_HALF_ALL_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SOURCES) \
     $(shell find $(LIBC_TOP_HALF_SOURCES) -name \*.c)
 
-# Set the target variables. The multiarch triple is the same as the
-# regular triple for wasm, except that it excludes the vendor field.
-TARGET_TRIPLE = wasm32-unknown-wasi
+# Set the target variables. Multiarch triples notably omit the vendor
+# field, which happens to be what we do for the main target triple too.
+TARGET_TRIPLE = wasm32-wasi
 MULTIARCH_TRIPLE = wasm32-wasi
 
 # These variables describe the locations of various files and

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ aren't stable yet.
 It's several things.
 
 First, it's a usable libc. It builds a "sysroot" which can be pointed to by
-compilers, such as Clang 8.0, using the wasm32-unknown-wasi target triple.
-It's a work in progress, but it is already sufficient to run basic programs.
+compilers, such as Clang 8.0, using the wasm32-wasi target. It's a work in
+progress, but it is already sufficient to run basic programs.
 
 Second, it's a "reference" implementation, which means the interfaces defined
 here can be used by other tools and libraries, even if they don't use all the

--- a/libc-top-half/musl/include/setjmp.h
+++ b/libc-top-half/musl/include/setjmp.h
@@ -35,7 +35,7 @@ _Noreturn void longjmp (jmp_buf, int);
 
 #define setjmp setjmp
 #else
-#warning setjmp is not yet implemented for wasm32-unknown-wasi
+#warning setjmp is not yet implemented for WASI
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
LLVM permits targets with "unknown" triples to omit the vendor, and some targets recently are doing this (eg. x86_64-fuchsia), and [multiarch tuples](https://wiki.debian.org/Multiarch/Tuples) already do this as well.

And it's less typing: just wasm32-wasi.