### PR TITLE
Rename printf_no_Lf to __small_printf

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -176,6 +176,7 @@ __signgam
 __sin
 __sindf
 __sinl
+__small_printf
 __stderr_FILE
 __stderr_used
 __stderr_used
@@ -795,7 +796,6 @@ powl
 pread
 preadv
 printf
-printf_no_Lf
 program_invocation_name
 program_invocation_short_name
 pselect

--- a/libc-top-half/musl/src/stdio/printf.c
+++ b/libc-top-half/musl/src/stdio/printf.c
@@ -13,5 +13,5 @@ int printf(const char *restrict fmt, ...)
 #ifdef __wasilibc_unmodified_upstream // Changes to optimize printf/scanf when long double isn't needed
 #else
 weak_alias(printf, iprintf);
-weak_alias(printf, printf_no_Lf);
+weak_alias(printf, __small_printf);
 #endif


### PR DESCRIPTION
Step 1 of better no long double optimizations:
- rename `printf_no_Lf` to `__small_printf` according to https://reviews.llvm.org/D57620.