### PR TITLE
Ensure that `environ` is always initialized.

### DIFF
--- a/libc-bottom-half/crt/crt1.c
+++ b/libc-bottom-half/crt/crt1.c
@@ -44,11 +44,6 @@ static __wasi_errno_t populate_environ(void) {
     if (err != __WASI_ESUCCESS) {
         return err;
     }
-    /* If there's no environment pairs, make sure environ is null and return. */
-    if (environ_count == 0) {
-        __environ = NULL;
-        return __WASI_ESUCCESS;
-    }
 
     /* Allocate memory for the array of pointers, plus one terminating null pointer. */
     __environ = malloc(sizeof(char *) * (environ_count + 1));


### PR DESCRIPTION
Initialize `environ` even if there are no environment variables, so that
it alwasy points to a NULL-terminated array even if that array just
contains the NULL. This fixes src/functional/env.c.