### PR TITLE
Fix the return value of the first call to uselocale.

### DIFF
--- a/libc-top-half/musl/src/locale/uselocale.c
+++ b/libc-top-half/musl/src/locale/uselocale.c
@@ -11,6 +11,7 @@ locale_t __uselocale(locale_t new)
 	locale_t old = self->locale;
 #else
 	locale_t old = libc.current_locale;
+	if (!old) old = LC_GLOBAL_LOCALE;
 #endif
 	locale_t global = &libc.global_locale;
 


### PR DESCRIPTION
The first call to uselocale should return LC_GLOBAL_LOCALE. This fixes
src/regression/uselocale-0.c in libc-test.