### PR TITLE
Add __restrict qualifiers to the fstatat declaration.

### DIFF
--- a/libc-bottom-half/headers/public/__header_unistd.h
+++ b/libc-bottom-half/headers/public/__header_unistd.h
@@ -21,7 +21,7 @@ extern "C" {
 int close(int fd);
 int faccessat(int, const char *, int, int);
 int dup(int);
-int fstatat(int, const char *, struct stat *, int);
+int fstatat(int, const char *__restrict, struct stat *__restrict, int);
 int renameat(int, const char *, int, const char *);
 int openat(int, const char *, int, ...);
 void *sbrk(intptr_t increment);


### PR DESCRIPTION
This makes it consistent with its definition. There's no functionality change here, this is just keeping things tidy.