### PR TITLE
Rename __wasilibc_rmfileat to __wasilibc_unlinkat.

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -241,8 +241,8 @@ __wasilibc_find_relpath
 __wasilibc_init_preopen
 __wasilibc_register_preopened_fd
 __wasilibc_rmdirat
-__wasilibc_rmfileat
 __wasilibc_tell
+__wasilibc_unlinkat
 __wcscoll_l
 __wcsftime_l
 __wcsxfrm_l

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/__wasilibc_unlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/__wasilibc_unlinkat.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <string.h>
 
-int __wasilibc_rmfileat(int fd, const char *path) {
+int __wasilibc_unlinkat(int fd, const char *path) {
     size_t path_len = strlen(path);
     __wasi_errno_t error = __wasi_path_unlink_file(fd, path, path_len);
     if (error != 0) {

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/unlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/unlinkat.c
@@ -30,6 +30,6 @@ int unlinkat(int fd, const char *path, int flag) {
   if ((flag & AT_REMOVEDIR) != 0) {
     return __wasilibc_rmdirat(fd, path);
   }
-  return __wasilibc_rmfileat(fd, path);
+  return __wasilibc_unlinkat(fd, path);
 #endif
 }

--- a/libc-bottom-half/headers/public/wasi/libc.h
+++ b/libc-bottom-half/headers/public/wasi/libc.h
@@ -10,7 +10,7 @@ extern "C" {
 void __wasilibc_init_preopen(void);
 int __wasilibc_register_preopened_fd(int fd, const char *path);
 int __wasilibc_fd_renumber(int fd, int newfd);
-int __wasilibc_rmfileat(int fd, const char *path);
+int __wasilibc_unlinkat(int fd, const char *path);
 int __wasilibc_rmdirat(int fd, const char *path);
 off_t __wasilibc_tell(int fd);
 

--- a/libc-bottom-half/libpreopen/lib/po_libc_wrappers.c
+++ b/libc-bottom-half/libpreopen/lib/po_libc_wrappers.c
@@ -409,7 +409,7 @@ unlink(const char *pathname)
 	    return -1;
 	}
 
-	return __wasilibc_rmfileat(rel_pathname.dirfd, rel_pathname.relative_path);
+	return __wasilibc_unlinkat(rel_pathname.dirfd, rel_pathname.relative_path);
 }
 
 int
@@ -451,7 +451,7 @@ remove(const char *pathname)
 	    return -1;
 	}
 
-	int r = __wasilibc_rmfileat(rel_pathname.dirfd, rel_pathname.relative_path);
+	int r = __wasilibc_unlinkat(rel_pathname.dirfd, rel_pathname.relative_path);
 	if (r != 0 && (errno == EISDIR || errno == ENOTCAPABLE))
 		r = __wasilibc_rmdirat(rel_pathname.dirfd, rel_pathname.relative_path);
 	return r;


### PR DESCRIPTION
This aligns WASI libc's names with WASI's names a little better, concerning "removing" vs. "unlinking". Directories are "removed" while files are "unlinked", which reflects terminology used by POSIX in some places. 

That said, POSIX isn't perfectly consistent about this, so I'm not tied to this naming scheme. If anyone has any better ideas, I'm open to suggestions.

This is a public API change, but I'm hoping not many people are depending on `__wasilibc_rmfileat` yet.