### PR TITLE
Re-enable '%s' in strftime.

### DIFF
--- a/libc-top-half/musl/src/time/strftime.c
+++ b/libc-top-half/musl/src/time/strftime.c
@@ -122,12 +122,10 @@ const char *__strftime_fmt_1(char (*s)[100], size_t *l, int f, const struct tm *
 	case 'R':
 		fmt = "%H:%M";
 		goto recu_strftime;
-#ifdef __wasilibc_unmodified_upstream // timezone data
 	case 's':
 		val = __tm_to_secs(tm) - tm->__tm_gmtoff;
 		width = 1;
 		goto number;
-#endif
 	case 'S':
 		val = tm->tm_sec;
 		goto number;


### PR DESCRIPTION
This was commented out earlier when timezone handling was more in flux,
but it's ok to minimally support this now.

This fixes src/functional/strftime.c in libc-test.