### PR TITLE
Don't declare dup in unistd.h.

### DIFF
--- a/libc-bottom-half/headers/public/__header_unistd.h
+++ b/libc-bottom-half/headers/public/__header_unistd.h
@@ -20,7 +20,6 @@ extern "C" {
 
 int close(int fd);
 int faccessat(int, const char *, int, int);
-int dup(int);
 int fstatat(int, const char *__restrict, struct stat *__restrict, int);
 int renameat(int, const char *, int, const char *);
 int openat(int, const char *, int, ...);


### PR DESCRIPTION
Dup isn't defined in libc.a, so don't declare it.