### PR TITLE
Fix fmemopen and friends to use the correct SEEK_* values.

### DIFF
--- a/libc-top-half/musl/src/stdio/fmemopen.c
+++ b/libc-top-half/musl/src/stdio/fmemopen.c
@@ -26,7 +26,15 @@ fail:
 		errno = EINVAL;
 		return -1;
 	}
+#ifdef __wasilibc_unmodified_upstream // WASI's SEEK_* constants have different values.
 	base = (size_t [3]){0, c->pos, c->len}[whence];
+#else
+	base = (size_t [3]) {
+            [SEEK_SET] = 0,
+            [SEEK_CUR] = c->pos,
+            [SEEK_END] = c->len
+        }[whence];
+#endif
 	if (off < -base || off > (ssize_t)c->size-base) goto fail;
 	return c->pos = base+off;
 }

--- a/libc-top-half/musl/src/stdio/open_memstream.c
+++ b/libc-top-half/musl/src/stdio/open_memstream.c
@@ -29,7 +29,15 @@ fail:
 		errno = EINVAL;
 		return -1;
 	}
+#ifdef __wasilibc_unmodified_upstream // WASI's SEEK_* constants have different values.
 	base = (size_t [3]){0, c->pos, c->len}[whence];
+#else
+	base = (size_t [3]) {
+            [SEEK_SET] = 0,
+            [SEEK_CUR] = c->pos,
+            [SEEK_END] = c->len
+        }[whence];
+#endif
 	if (off < -base || off > SSIZE_MAX-base) goto fail;
 	return c->pos = base+off;
 }

--- a/libc-top-half/musl/src/stdio/open_wmemstream.c
+++ b/libc-top-half/musl/src/stdio/open_wmemstream.c
@@ -31,7 +31,15 @@ fail:
 		errno = EINVAL;
 		return -1;
 	}
+#ifdef __wasilibc_unmodified_upstream // WASI's SEEK_* constants have different values.
 	base = (size_t [3]){0, c->pos, c->len}[whence];
+#else
+	base = (size_t [3]) {
+            [SEEK_SET] = 0,
+            [SEEK_CUR] = c->pos,
+            [SEEK_END] = c->len
+        }[whence];
+#endif
 	if (off < -base || off > SSIZE_MAX/4-base) goto fail;
 	memset(&c->mbs, 0, sizeof c->mbs);
 	return c->pos = base+off;


### PR DESCRIPTION
WASI's values for SEEK_CUR, SEEK_SET, and SEEK_END differ from musl's
values, so fix musl code that bakes in knowledge of these values.

This fixes src/functional/memstream.c.