### PR TITLE
Update to libpreopen 8835639f27fc42d32096d59d294a0bbb857dc368.

### DIFF
--- a/libc-bottom-half/README.md
+++ b/libc-bottom-half/README.md
@@ -14,7 +14,7 @@ libpreopen, and we have several customizations for use in a WebAssembly sysroot.
 The upstream repositories and versions used here are:
 
 cloudlibc - https://github.com/NuxiNL/cloudlibc 8835639f27fc42d32096d59d294a0bbb857dc368
-libpreopen - https://github.com/musec/libpreopen 8265fc50b9db3730c250597bdd084f1e728f3e48
+libpreopen - https://github.com/musec/libpreopen b29e9287cc75a7db7291ce3eb468a3d2bad8ceb1
 
 Whole files which are unused are omitted. Changes to upstream code are wrapped
 in preprocessor directives controlled by the macro `__wasilibc_unmodified_upstream`,

--- a/libc-bottom-half/libpreopen/lib/libpreopen.c
+++ b/libc-bottom-half/libpreopen/lib/libpreopen.c
@@ -174,7 +174,7 @@ po_find(struct po_map* map, const char *path,
 
 	relpath = path + bestlen;
 
-	if (*relpath == '/') {
+	while (*relpath == '/') {
 		relpath++;
 	}
 


### PR DESCRIPTION
This replaces our custom `unlink` wrapper with an upstream one. We still
end up replacing the entire body with local changes, but this makes it
easier to see what those changes are.

The other change here is a fix to ignore repeated '/'s in paths.