### PR TITLE
More math builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,9 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/prng/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/conf/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/ctype/*.c) \
-    $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/math/*.c) \
+    $(filter-out %/__signbit.c %/__signbitf.c %/__signbitl.c \
+                 %/__fpclassify.c %/__fpclassifyf.c %/__fpclassifyl.c, \
+                 $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/math/*.c)) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/complex/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/crypt/*.c)
 MUSL_PRINTSCAN_SOURCES = \

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -52,9 +52,6 @@ __flbf
 __floatscan
 __fmodeflags
 __fopen_rb_ca
-__fpclassify
-__fpclassifyf
-__fpclassifyl
 __fpending
 __fpurge
 __fputwc_unlocked
@@ -169,9 +166,6 @@ __secs_to_zone
 __seed48
 __shgetc
 __shlim
-__signbit
-__signbitf
-__signbitl
 __signgam
 __sin
 __sindf

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3085,7 +3085,6 @@
 #define __INT_LEAST8_MAX__ 127
 #define __INT_LEAST8_TYPE__ signed char
 #define __INT_MAX__ 2147483647
-#define __ISREL_DEF(rel,op,type) static __inline int __is##rel(type __x, type __y) { return !isunordered(__x,__y) && __x op __y; }
 #define __IS_CX(x) (__IS_FP(x) && sizeof(x) == sizeof((x)+I))
 #define __IS_FP(x) (sizeof((x)+1ULL) == sizeof((x)+1.0f))
 #define __IS_REAL(x) (__IS_FP(x) && 2*sizeof(x) == sizeof((x)+I))
@@ -3548,7 +3547,6 @@
 #define __restrict restrict
 #define __tg_complex(fun,x) (__RETCAST_CX(x)( __FLTCX((x)+I) && __IS_FP(x) ? fun ## f (x) : __LDBLCX((x)+I) ? fun ## l (x) : fun(x) ))
 #define __tg_complex_retreal(fun,x) (__RETCAST_REAL(x)( __FLTCX((x)+I) && __IS_FP(x) ? fun ## f (x) : __LDBLCX((x)+I) ? fun ## l (x) : fun(x) ))
-#define __tg_pred_2(x,y,p) ( sizeof((x)+(y)) == sizeof(float) ? p##f(x, y) : sizeof((x)+(y)) == sizeof(double) ? p(x, y) : p##l(x, y) )
 #define __tg_real(fun,x) (__RETCAST(x)__tg_real_nocast(fun, x))
 #define __tg_real_2(fun,x,y) (__RETCAST_2(x, y)( __FLT(x) && __FLT(y) ? fun ## f (x, y) : __LDBL((x)+(y)) ? fun ## l (x, y) : fun(x, y) ))
 #define __tg_real_2_1(fun,x,y) (__RETCAST(x)( __FLT(x) ? fun ## f (x, y) : __LDBL(x) ? fun ## l (x, y) : fun(x, y) ))
@@ -3700,7 +3698,7 @@
 #define fmin(x,y) __tg_real_2(fmin, (x), (y))
 #define fmod(x,y) __tg_real_2(fmod, (x), (y))
 #define fopen64 fopen
-#define fpclassify(x) __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x)
+#define fpclassify(x) (__builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x))
 #define fpos64_t fpos_t
 #define freopen64 freopen
 #define frexp(x,y) __tg_real_2_1(frexp, (x), (y))
@@ -3781,21 +3779,21 @@
 #define isascii(a) (0 ? isascii(a) : (unsigned)(a) < 128)
 #define isclr(x,i) !isset(x,i)
 #define isdigit(a) (0 ? isdigit(a) : ((unsigned)(a)-'0') < 10)
-#define isfinite(x) __builtin_isfinite(x)
+#define isfinite(x) (__builtin_isfinite(x))
 #define isgraph(a) (0 ? isgraph(a) : ((unsigned)(a)-0x21) < 0x5e)
-#define isgreater(x,y) __tg_pred_2(x, y, __isgreater)
-#define isgreaterequal(x,y) __tg_pred_2(x, y, __isgreaterequal)
-#define isinf(x) __builtin_isinf(x)
-#define isless(x,y) __tg_pred_2(x, y, __isless)
-#define islessequal(x,y) __tg_pred_2(x, y, __islessequal)
-#define islessgreater(x,y) __tg_pred_2(x, y, __islessgreater)
+#define isgreater(x,y) (__builtin_isgreater(x, y))
+#define isgreaterequal(x,y) (__builtin_isgreaterequal(x, y))
+#define isinf(x) (__builtin_isinf(x))
+#define isless(x,y) (__builtin_isless(x, y))
+#define islessequal(x,y) (__builtin_islessequal(x, y))
+#define islessgreater(x,y) (__builtin_islessgreater(x, y))
 #define islower(a) (0 ? islower(a) : ((unsigned)(a)-'a') < 26)
-#define isnan(x) __builtin_isnan(x)
-#define isnormal(x) __builtin_isnormal(x)
+#define isnan(x) (__builtin_isnan(x))
+#define isnormal(x) (__builtin_isnormal(x))
 #define isprint(a) (0 ? isprint(a) : ((unsigned)(a)-0x20) < 0x5f)
 #define isset(x,i) __bitop(x,i,&)
 #define isspace(a) __isspace(a)
-#define isunordered(x,y) (isnan((x)) ? ((void)(y),1) : isnan((y)))
+#define isunordered(x,y) (__builtin_isunordered(x, y))
 #define isupper(a) (0 ? isupper(a) : ((unsigned)(a)-'A') < 26)
 #define iswdigit(a) (0 ? iswdigit(a) : ((unsigned)(a)-'0') < 10)
 #define ldexp(x,y) __tg_real_2_1(ldexp, (x), (y))
@@ -3929,7 +3927,7 @@
 #define si_upper __si_fields.__sigfault.__first.__addr_bnd.si_upper
 #define si_utime __si_fields.__si_common.__second.__sigchld.si_utime
 #define si_value __si_fields.__si_common.__second.si_value
-#define signbit(x) __builtin_signbit(x)
+#define signbit(x) (__builtin_signbit(x))
 #define sin(x) __tg_real_complex(sin, (x))
 #define sinh(x) __tg_real_complex(sinh, (x))
 #define sqrt(x) __tg_real_complex(sqrt, (x))

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2891,7 +2891,6 @@
 #define __CHAR16_TYPE__ unsigned short
 #define __CHAR32_TYPE__ unsigned int
 #define __CHAR_BIT__ 8
-#define __CIMAG(x,t) (+(union { _Complex t __z; t __xy[2]; }){(_Complex t)(x)}.__xy[1])
 #define __compiler_ATOMIC_BOOL_LOCK_FREE 2
 #define __compiler_ATOMIC_CHAR16_T_LOCK_FREE 2
 #define __compiler_ATOMIC_CHAR32_T_LOCK_FREE 2
@@ -3665,8 +3664,6 @@
 #define cbrt(x) __tg_real(cbrt, (x))
 #define ceil(x) __tg_real(ceil, (x))
 #define cimag(x) __tg_complex_retreal(cimag, (x))
-#define cimagf(x) __CIMAG(x, float)
-#define cimagl(x) __CIMAG(x, long double)
 #define clrbit(x,i) __bitop(x,i,&=~)
 #define compl ~
 #define complex _Complex
@@ -3676,8 +3673,6 @@
 #define cosh(x) __tg_real_complex(cosh, (x))
 #define cproj(x) __tg_complex(cproj, (x))
 #define creal(x) __tg_complex_retreal(creal, (x))
-#define crealf(x) ((float)(x))
-#define creall(x) ((long double)(x))
 #define creat64 creat
 #define d_fileno d_ino
 #define direct dirent

--- a/libc-top-half/musl/include/complex.h
+++ b/libc-top-half/musl/include/complex.h
@@ -101,6 +101,7 @@ double creal(double complex);
 float crealf(float complex);
 long double creall(long double complex);
 
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's real/imag operators rather than union type punning */
 #ifndef __cplusplus
 #define __CIMAG(x, t) \
 	(+(union { _Complex t __z; t __xy[2]; }){(_Complex t)(x)}.__xy[1])
@@ -112,6 +113,7 @@ long double creall(long double complex);
 #define cimag(x) __CIMAG(x, double)
 #define cimagf(x) __CIMAG(x, float)
 #define cimagl(x) __CIMAG(x, long double)
+#endif
 #endif
 
 #if __STDC_VERSION__ >= 201112L

--- a/libc-top-half/musl/include/math.h
+++ b/libc-top-half/musl/include/math.h
@@ -36,11 +36,11 @@ extern "C" {
 #define FP_SUBNORMAL 3
 #define FP_NORMAL    4
 
+#ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of the fpclassify-like operations */
 int __fpclassify(double);
 int __fpclassifyf(float);
 int __fpclassifyl(long double);
 
-#ifdef __wasilibc_unmodified_upstream /* Force compiler to optimize these macros */
 static __inline unsigned __FLOAT_BITS(float __f)
 {
 	union {float __f; unsigned __i;} __u;
@@ -78,35 +78,15 @@ static __inline unsigned long long __DOUBLE_BITS(double __f)
 	sizeof(x) == sizeof(float) ? (__FLOAT_BITS(x) & 0x7fffffff) < 0x7f800000 : \
 	sizeof(x) == sizeof(double) ? (__DOUBLE_BITS(x) & -1ULL>>1) < 0x7ffULL<<52 : \
 	__fpclassifyl(x) > FP_INFINITE)
-#else
-
-#define fpclassify(x) __builtin_fpclassify(FP_NAN, FP_INFINITE, \
-	FP_NORMAL, FP_SUBNORMAL, FP_ZERO, x)
-
-#define isinf(x) __builtin_isinf(x)
-
-#define isnan(x) __builtin_isnan(x)
-
-#define isnormal(x) __builtin_isnormal(x)
-
-#define isfinite(x) __builtin_isfinite(x)
-
-#endif
 
 int __signbit(double);
 int __signbitf(float);
 int __signbitl(long double);
 
-#ifdef __wasilibc_unmodified_upstream /* Force compiler to optimize this macro */
 #define signbit(x) ( \
 	sizeof(x) == sizeof(float) ? (int)(__FLOAT_BITS(x)>>31) : \
 	sizeof(x) == sizeof(double) ? (int)(__DOUBLE_BITS(x)>>63) : \
 	__signbitl(x) )
-#else
-
-#define signbit(x) __builtin_signbit(x)
-
-#endif
 
 #define isunordered(x,y) (isnan((x)) ? ((void)(y),1) : isnan((y)))
 
@@ -140,6 +120,22 @@ __ISREL_DEF(greaterequall, >=, long double)
 #define islessgreater(x, y)     __tg_pred_2(x, y, __islessgreater)
 #define isgreater(x, y)         __tg_pred_2(x, y, __isgreater)
 #define isgreaterequal(x, y)    __tg_pred_2(x, y, __isgreaterequal)
+#else
+#define fpclassify(x)        (__builtin_fpclassify(FP_NAN, FP_INFINITE, \
+                                                   FP_NORMAL, FP_SUBNORMAL, \
+                                                   FP_ZERO, x))
+#define isinf(x)             (__builtin_isinf(x))
+#define isnan(x)             (__builtin_isnan(x))
+#define isnormal(x)          (__builtin_isnormal(x))
+#define isfinite(x)          (__builtin_isfinite(x))
+#define signbit(x)           (__builtin_signbit(x))
+#define isunordered(x, y)    (__builtin_isunordered(x, y))
+#define isless(x, y)         (__builtin_isless(x, y))
+#define islessequal(x, y)    (__builtin_islessequal(x, y))
+#define islessgreater(x, y)  (__builtin_islessgreater(x, y))
+#define isgreater(x, y)      (__builtin_isgreater(x, y))
+#define isgreaterequal(x, y) (__builtin_isgreaterequal(x, y))
+#endif
 
 double      acos(double);
 float       acosf(float);


### PR DESCRIPTION
This builds on a64f654488f37605e1df5e664eada5c3388f79ba and converts `isless`/`isgreater`/etc. to builtin functions too, and cleans up some remnants of the old non-builtin `signbit` and `fpclassify` implementations.

And while here, rely on the compiler recognizing creal/cimag as builtins (both clang and GCC do this), so we can eliminate the last use of union-based type punning in the math headers.