### PR TITLE
Move the SEEK_* macros into their own header and use it from fcntl.h.

### DIFF
--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -20,6 +20,7 @@
 #include <__header_unistd.h>
 #include <__macro_FD_SETSIZE.h>
 #include <__macro_PAGESIZE.h>
+#include <__seek.h>
 #include <__struct_dirent.h>
 #include <__struct_in6_addr.h>
 #include <__struct_in_addr.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3582,6 +3582,7 @@
 #define __wasilibc___headers_stdlib_h 
 #define __wasilibc___headers_string_h 
 #define __wasilibc___macro_FD_SETSIZE_h 
+#define __wasilibc___seek_h 
 #define __wasilibc___struct_dirent_h 
 #define __wasilibc___struct_in6_addr_h 
 #define __wasilibc___struct_in_addr_h 

--- a/libc-bottom-half/headers/public/__header_fcntl.h
+++ b/libc-bottom-half/headers/public/__header_fcntl.h
@@ -2,6 +2,7 @@
 #define __wasilibc___header_fcntl_h
 
 #include <wasi/core.h>
+#include <__seek.h>
 
 #define O_APPEND __WASI_FDFLAG_APPEND
 #define O_DSYNC __WASI_FDFLAG_DSYNC

--- a/libc-bottom-half/headers/public/__header_unistd.h
+++ b/libc-bottom-half/headers/public/__header_unistd.h
@@ -3,11 +3,7 @@
 
 struct stat;
 
-#include <wasi/core.h>
-
-#define SEEK_CUR __WASI_WHENCE_CUR
-#define SEEK_END __WASI_WHENCE_END
-#define SEEK_SET __WASI_WHENCE_SET
+#include <__seek.h>
 
 #define F_OK 0
 #define R_OK 1

--- a/libc-bottom-half/headers/public/__seek.h
+++ b/libc-bottom-half/headers/public/__seek.h
@@ -1,0 +1,10 @@
+#ifndef __wasilibc___seek_h
+#define __wasilibc___seek_h
+
+#include <wasi/core.h>
+
+#define SEEK_CUR __WASI_WHENCE_CUR
+#define SEEK_END __WASI_WHENCE_END
+#define SEEK_SET __WASI_WHENCE_SET
+
+#endif

--- a/libc-top-half/musl/include/stdio.h
+++ b/libc-top-half/musl/include/stdio.h
@@ -49,7 +49,7 @@ extern "C" {
 #define SEEK_CUR 1
 #define SEEK_END 2
 #else
-#include <__header_unistd.h>
+#include <__seek.h>
 #endif
 
 #define _IOFBF 0


### PR DESCRIPTION
POSIX requires fcntl.h to define the SEEK_* macros, so this satisfies
that requirement. Also, this allows <stdio.h> to avoid including as much
unnecessary content.

This fixes one issue with src/api/fcntl.c.