### PR TITLE
Move the mode_t macros into their own header.

### DIFF
--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -20,6 +20,7 @@
 #include <__header_unistd.h>
 #include <__macro_FD_SETSIZE.h>
 #include <__macro_PAGESIZE.h>
+#include <__mode_t.h>
 #include <__seek.h>
 #include <__struct_dirent.h>
 #include <__struct_in6_addr.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3579,6 +3579,7 @@
 #define __wasilibc___headers_stdlib_h 
 #define __wasilibc___headers_string_h 
 #define __wasilibc___macro_FD_SETSIZE_h 
+#define __wasilibc___mode_t_h 
 #define __wasilibc___seek_h 
 #define __wasilibc___struct_dirent_h 
 #define __wasilibc___struct_in6_addr_h 

--- a/libc-bottom-half/headers/public/__header_fcntl.h
+++ b/libc-bottom-half/headers/public/__header_fcntl.h
@@ -3,6 +3,7 @@
 
 #include <wasi/core.h>
 #include <__seek.h>
+#include <__mode_t.h>
 
 #define O_APPEND __WASI_FDFLAG_APPEND
 #define O_DSYNC __WASI_FDFLAG_DSYNC

--- a/libc-bottom-half/headers/public/__header_sys_stat.h
+++ b/libc-bottom-half/headers/public/__header_sys_stat.h
@@ -7,39 +7,7 @@
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
 
-#define S_IFMT \
-    (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
-#define S_IFBLK (0x6000)
-#define S_IFCHR (0x2000)
-#define S_IFDIR (0x4000)
-#define S_IFLNK (0xa000)
-#define S_IFREG (0x8000)
-#define S_IFSOCK (0xc000)
-#define S_IFIFO (0xc000)
-
-#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
-#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
-#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
-#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
-#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
-#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
-#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
-
-#define S_IXOTH (0x1)
-#define S_IWOTH (0x2)
-#define S_IROTH (0x4)
-#define S_IRWXO (S_IXOTH | S_IWOTH | S_IROTH)
-#define S_IXGRP (0x8)
-#define S_IWGRP (0x10)
-#define S_IRGRP (0x20)
-#define S_IRWXG (S_IXGRP | S_IWGRP | S_IRGRP)
-#define S_IXUSR (0x40)
-#define S_IWUSR (0x80)
-#define S_IRUSR (0x100)
-#define S_IRWXU (S_IXUSR | S_IWUSR | S_IRUSR)
-#define S_ISVTX (0x200)
-#define S_ISGID (0x400)
-#define S_ISUID (0x800)
+#include <__mode_t.h>
 
 #define UTIME_NOW (-1)
 #define UTIME_OMIT (-2)

--- a/libc-bottom-half/headers/public/__mode_t.h
+++ b/libc-bottom-half/headers/public/__mode_t.h
@@ -1,0 +1,38 @@
+#ifndef __wasilibc___mode_t_h
+#define __wasilibc___mode_t_h
+
+#define S_IFMT \
+    (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
+#define S_IFBLK (0x6000)
+#define S_IFCHR (0x2000)
+#define S_IFDIR (0x4000)
+#define S_IFLNK (0xa000)
+#define S_IFREG (0x8000)
+#define S_IFSOCK (0xc000)
+#define S_IFIFO (0xc000)
+
+#define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
+#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
+#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
+
+#define S_IXOTH (0x1)
+#define S_IWOTH (0x2)
+#define S_IROTH (0x4)
+#define S_IRWXO (S_IXOTH | S_IWOTH | S_IROTH)
+#define S_IXGRP (0x8)
+#define S_IWGRP (0x10)
+#define S_IRGRP (0x20)
+#define S_IRWXG (S_IXGRP | S_IWGRP | S_IRGRP)
+#define S_IXUSR (0x40)
+#define S_IWUSR (0x80)
+#define S_IRUSR (0x100)
+#define S_IRWXU (S_IXUSR | S_IWUSR | S_IRUSR)
+#define S_ISVTX (0x200)
+#define S_ISGID (0x400)
+#define S_ISUID (0x800)
+
+#endif


### PR DESCRIPTION
This allows them to be defined by <fcntl.h> as well, as specified by
POSIX.

This fixes a part of src/api/fcntl.c.