### PR TITLE
Use builtin operations to implement several math library functions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
                  %/fabsf.c %/fabs.c \
                  %/copysignf.c %/copysign.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/math/*.c)) \
-    $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/complex/*.c) \
+    $(filter-out %/crealf.c %/creal.c \
+                 %/cimagf.c %/cimag.c, \
+                 $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/complex/*.c)) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/crypt/*.c)
 MUSL_PRINTSCAN_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/internal/floatscan.c \

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,15 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/conf/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/ctype/*.c) \
     $(filter-out %/__signbit.c %/__signbitf.c %/__signbitl.c \
-                 %/__fpclassify.c %/__fpclassifyf.c %/__fpclassifyl.c, \
+                 %/__fpclassify.c %/__fpclassifyf.c %/__fpclassifyl.c \
+                 %/ceilf.c %/ceil.c \
+                 %/floorf.c %/floor.c \
+                 %/truncf.c %/trunc.c \
+                 %/rintf.c %/rint.c \
+                 %/nearbyintf.c %/nearbyint.c \
+                 %/sqrtf.c %/sqrt.c \
+                 %/fabsf.c %/fabs.c \
+                 %/copysignf.c %/copysign.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/math/*.c)) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/complex/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/crypt/*.c)

--- a/basics/sources/complex-builtins.c
+++ b/basics/sources/complex-builtins.c
@@ -1,0 +1,21 @@
+// Each of the following complex functions can be implemented with a single
+// wasm instruction, so use that implementation rather than the portable
+// one in libm.
+
+#include <complex.h>
+
+float crealf(float _Complex x) {
+    return __real__ x;
+}
+
+double creal(double _Complex x) {
+    return __real__ x;
+}
+
+float cimagf(float _Complex x) {
+    return __imag__ x;
+}
+
+double cimag(double _Complex x) {
+    return __imag__ x;
+}

--- a/basics/sources/math-builtins.c
+++ b/basics/sources/math-builtins.c
@@ -1,0 +1,69 @@
+// Each of the following math functions can be implemented with a single
+// wasm instruction, so use that implementation rather than the portable
+// one in libm.
+
+#include <math.h>
+
+float fabsf(float x) {
+    return __builtin_fabsf(x);
+}
+
+double fabs(double x) {
+    return __builtin_fabs(x);
+}
+
+float sqrtf(float x) {
+    return __builtin_sqrtf(x);
+}
+
+double sqrt(double x) {
+    return __builtin_sqrt(x);
+}
+
+float copysignf(float x, float y) {
+    return __builtin_copysignf(x, y);
+}
+
+double copysign(double x, double y) {
+    return __builtin_copysign(x, y);
+}
+
+float ceilf(float x) {
+    return __builtin_ceilf(x);
+}
+
+double ceil(double x) {
+    return __builtin_ceil(x);
+}
+
+float floorf(float x) {
+    return __builtin_floorf(x);
+}
+
+double floor(double x) {
+    return __builtin_floor(x);
+}
+
+float truncf(float x) {
+    return __builtin_truncf(x);
+}
+
+double trunc(double x) {
+    return __builtin_trunc(x);
+}
+
+float nearbyintf(float x) {
+    return __builtin_nearbyintf(x);
+}
+
+double nearbyint(double x) {
+    return __builtin_nearbyint(x);
+}
+
+float rintf(float x) {
+    return __builtin_rintf(x);
+}
+
+double rint(double x) {
+    return __builtin_rint(x);
+}


### PR DESCRIPTION
Clang usually replaces calls to functions like `sqrt` with builtins automatically [0], however we still need to provide a library definition of `sqrt` for cases where it's actually called or has its address taken. However even in those cases, we don't actually want to use portable C implementations of `sqrt` or other functions; it's preferable to use the compiler builtins.

[0] It actually doesn't currently do this within WASI libc itself, because we compile with -fno-builtin, however fixing that is a separate topic.