### PR TITLE
Don't create dummy libs for libc++/libc++abi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ finish: startup_files libc
 	#
 	# Create empty placeholder libraries.
 	#
-	for name in m rt pthread crypt util xnet resolv dl c++ c++abi; do \
+	for name in m rt pthread crypt util xnet resolv dl; do \
 	    $(WASM_AR) crs "$(SYSROOT_LIB)/lib$${name}.a"; \
 	done
 


### PR DESCRIPTION
My understanding is that these dummy libs represent libraries who's
contents, under musl, live in libc itself rather than being split out
into separate libs.

libc++/libc++abi are not provided my musl so doesn't make sense to
pretend that we provide them.